### PR TITLE
Add IsCheck function to Chess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- [#3](https://github.com/RchrdHndrcks/gochess/pull/3) Add IsCheck function to Board.

--- a/pkg/chess/chess.go
+++ b/pkg/chess/chess.go
@@ -13,10 +13,16 @@ import (
 type (
 	// Board represents a chess board.
 	Board interface {
+		// LoadPosition loads a position into the board from a string.
 		LoadPosition(string) error
+		// Square returns the piece in a square.
 		Square(c pkg.Coordinate) (int8, error)
+		// AvailableMoves returns all the available moves for the current turn, without checking
+		// if they are legal.
 		AvailableMoves(turn int8, inPassantSquare, castlePossibilities string) ([]string, error)
+		// MakeMove makes a move without checking if it is legal.
 		MakeMove(string) error
+		// Width returns the width of the board.
 		Width() int
 	}
 
@@ -293,6 +299,15 @@ func (c *Chess) unmakeMove() error {
 
 	c.toggleColor()
 	return nil
+}
+
+// IsCheck returns if the current turn is in check.
+func (c *Chess) IsCheck() (bool, error) {
+	if c.board == nil || reflect.ValueOf(c.board).IsNil() {
+		return false, fmt.Errorf("board cannot be nil")
+	}
+
+	return c.isCheck()
 }
 
 func (c *Chess) setProperties(FEN string) error {

--- a/pkg/chess/chess_test.go
+++ b/pkg/chess/chess_test.go
@@ -291,6 +291,57 @@ func TestMakeMove(t *testing.T) {
 	}
 }
 
+func TestIsCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []chess.Option
+		isCheck bool
+		errMsg  string
+	}{
+		{
+			name:    "Default",
+			opts:    []chess.Option{},
+			isCheck: false,
+		},
+		{
+			name:    "Custom FEN - king is in check",
+			opts:    []chess.Option{chess.WithFEN("k7/8/8/8/8/8/3q4/3K4 w - - 0 1")},
+			isCheck: true,
+		},
+		{
+			name:    "Custom FEN - king is not in check",
+			opts:    []chess.Option{chess.WithFEN("k7/8/8/8/8/8/8/3K4 w - - 0 1")},
+			isCheck: false,
+		},
+		{
+			name:    "Custom FEN - king is not in the board",
+			opts:    []chess.Option{chess.WithFEN("8/8/8/8/8/8/3q4/8 w - - 0 1")},
+			isCheck: false,
+			errMsg:  "failed to get king position: king not found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			c, errOpts := chess.NewChess(test.opts...)
+			require.Nil(t, errOpts)
+
+			// Act
+			isCheck, err := c.IsCheck()
+
+			// Assert
+			assert.Equal(t, test.isCheck, isCheck)
+			if test.errMsg != "" {
+				require.NotNil(t, err)
+				assert.Equal(t, test.errMsg, err.Error())
+				return
+			}
+			assert.Nil(t, err)
+		})
+	}
+}
+
 func TestMakeMove_ScholarMate(t *testing.T) {
 	// Arrange
 	c, err := chess.NewChess()


### PR DESCRIPTION
## Description
IsCheck is a very useful function for Chess struct. It will add an easier way to know when the king of the current turn is under attack. 
This was not added to Board struct because I consider check as a Chess rule but I will pass this logic to it if the change makes the function considerably faster. 