### PR TITLE
Adjust API and efficiency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@ linters-settings:
     min-complexity: 15
   lll:
     line-length: 100
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
   revive:
     ignore-generated-header: true
     severity: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [#16](https://github.com/RchrdHndrcks/gochess/pull/16) Adjust API and efficiency.
+
 ## [1.1.0] - 2025-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Width() int
 Square(c Coordinate) (int8, error)
 MakeMove(origin, target Coordinate) error
 SetSquare(c Coordinate, p int8) error
-isValidCoordinate(c Coordinate) bool
+Clone() *Board
 ```
 
 ### Coordinates

--- a/board.go
+++ b/board.go
@@ -10,6 +10,23 @@ type Board struct {
 	width   int
 }
 
+// DefaultChessBoard returns the default chess board.
+func DefaultChessBoard() *Board {
+	return &Board{
+		squares: [][]int8{
+			{Black | Rook, Black | Knight, Black | Bishop, Black | Queen, Black | King, Black | Bishop, Black | Knight, Black | Rook},
+			{Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn},
+			{Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty},
+			{Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty},
+			{Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty},
+			{Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty},
+			{White | Pawn, White | Pawn, White | Pawn, White | Pawn, White | Pawn, White | Pawn, White | Pawn, White | Pawn},
+			{White | Rook, White | Knight, White | Bishop, White | Queen, White | King, White | Bishop, White | Knight, White | Rook},
+		},
+		width: 8,
+	}
+}
+
 // NewBoard creates a new board.
 //
 // It receives the width of the board and an optional 2D array of pieces.
@@ -103,6 +120,18 @@ func (b *Board) SetSquare(c Coordinate, p int8) error {
 
 	b.squares[c.Y][c.X] = p
 	return nil
+}
+
+// Clone returns a copy of the board.
+func (b *Board) Clone() *Board {
+	var cloned Board
+	cloned.squares = make([][]int8, b.width)
+	for i := range b.width {
+		cloned.squares[i] = make([]int8, b.width)
+		copy(cloned.squares[i], b.squares[i])
+	}
+	cloned.width = b.width
+	return &cloned
 }
 
 // isValidCoordinate returns true if the Coordinate is within the board bounds.

--- a/board_test.go
+++ b/board_test.go
@@ -394,3 +394,19 @@ func TestBoardIsValidCoordinate(t *testing.T) {
 		}
 	})
 }
+
+func TestClone(t *testing.T) {
+	t.Run("Clone", func(t *testing.T) {
+		// Arrange
+		originalBoard, err := gochess.NewBoard(3)
+		require.NoError(t, err)
+		clonedBoard := originalBoard
+
+		// Act
+		clonedBoard = clonedBoard.Clone()
+
+		// Assert
+		assert.NotSame(t, originalBoard, clonedBoard)
+		assert.Equal(t, *originalBoard, *clonedBoard)
+	})
+}

--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -1,0 +1,445 @@
+package chess
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/RchrdHndrcks/gochess"
+)
+
+var fenAnalysisRegex = regexp.MustCompile("[/0-9]")
+
+// loadPosition is a helper function that loads a board from a FEN string.
+//
+// The function will read the entire FEN string and will return an error if
+// the FEN string is invalid.
+//
+// The board and properties will not be modified if the FEN string is invalid.
+func (c *Chess) loadPosition(FEN string) error {
+	fenRows := strings.Split(FEN, "/")
+	if len(fenRows) != 8 {
+		return fmt.Errorf("invalid FEN: %s", FEN)
+	}
+
+	props := strings.Split(fenRows[7], " ")
+	if len(props) != 6 {
+		return fmt.Errorf("invalid FEN: %s", FEN)
+	}
+
+	fenRows[7] = props[0]
+
+	var whiteKing, blackKing int
+	var whiteKingPosition, blackKingPosition *gochess.Coordinate
+
+	brd := make([][]int8, 8, 8)
+	for y := range 8 {
+		row := make([]int8, 8, 8)
+
+		if len(fenRows[y]) == 0 || len(fenRows[y]) > 8 {
+			return fmt.Errorf("invalid FEN: %s", FEN)
+		}
+
+		for x := range 8 {
+			char := string(fenRows[y][0])
+			fenRows[y] = fenRows[y][1:]
+
+			n, err := strconv.Atoi(char)
+			// If c is not a number, it's a piece.
+			if err != nil {
+				p := gochess.Pieces[char]
+				row[x] = p
+				coor := gochess.Coor(x, y)
+				if p == gochess.King|gochess.White {
+					whiteKing++
+					whiteKingPosition = &coor
+				}
+				if p == gochess.King|gochess.Black {
+					blackKing++
+					blackKingPosition = &coor
+				}
+				continue
+			}
+
+			// If c is a number, reduce the number of empty squares from the FEN string.
+			n--
+			if n > 0 {
+				fenRows[y] = fmt.Sprintf("%d%s", n, fenRows[y])
+			}
+		}
+
+		if fenRows[y] != "" && fenRows[y] != "0" {
+			return fmt.Errorf("invalid FEN: %s", FEN)
+		}
+
+		brd[y] = row
+	}
+
+	// If any of the kings is not in the board, the position is invalid.
+	if whiteKing != 1 || blackKing != 1 {
+		return errors.New("invalid FEN: both kings must be in the board once")
+	}
+
+	// Make a copy of the actual chess struct because if
+	// the properties are invalid or the position is invalid
+	// the struct will not be modified.
+	copy := *c
+	b, _ := gochess.NewBoard(8, brd...)
+	c.board = b
+
+	// If the FEN is invalid, setProperties will
+	// return an error without modifying the board or the properties.
+	if err := c.setProperties(FEN); err != nil {
+		*c = copy
+		return fmt.Errorf("invalid FEN: %w", err)
+	}
+
+	legacyWhiteKingPosition := c.whiteKingPosition
+	legacyBlackKingPosition := c.blackKingPosition
+
+	c.whiteKingPosition = whiteKingPosition
+	c.blackKingPosition = blackKingPosition
+
+	if !c.isPositionLegal() {
+		c.whiteKingPosition = legacyWhiteKingPosition
+		c.blackKingPosition = legacyBlackKingPosition
+		*c = copy
+		return errors.New("invalid FEN: the current turn can capture the opponent king")
+	}
+
+	return nil
+}
+
+// calculateFEN returns the FEN string of the current position.
+//
+// If move is not empty, it will only update the specified move.
+// If more than one move is passed, it will update only the first move.
+func (c *Chess) calculateFEN(move ...string) string {
+	if c.blackKingPosition == nil || c.whiteKingPosition == nil {
+		return ""
+	}
+
+	ac := cmp.Or(c.availableCastles, "-")
+	ips := cmp.Or(c.enPassantSquare, "-")
+
+	var boardFEN string
+	if len(move) == 0 {
+		boardFEN = c.calculateEntireBoardFEN()
+	} else {
+		m := move[0]
+		origin, _ := AlgebraicToCoordinate(m[:2])
+		target, _ := AlgebraicToCoordinate(m[2:4])
+		boardFEN = c.calculateBoardFEN(origin.Y, target.Y)
+	}
+
+	return boardFEN + fmt.Sprintf(" %s %s %s %d %d", gochess.ColorNames[c.turn], ac, ips, c.halfMoves, c.movesCount)
+}
+
+// calculateBoardFEN returns the FEN string of the board without the properties.
+// If rows is not empty, it will only update the specified rows.
+func (c *Chess) calculateBoardFEN(rows ...int) string {
+	if len(rows) == 0 {
+		return c.calculateEntireBoardFEN()
+	}
+
+	r := strings.Split(strings.Split(c.actualFEN, " ")[0], "/")
+	for _, row := range rows {
+		r[row] = c.calculateRowFEN(row)
+	}
+
+	return strings.Join(r, "/")
+}
+
+func (c *Chess) calculateEntireBoardFEN() string {
+	fen := ""
+
+	for y := range c.board.Width() {
+		fen += c.calculateRowFEN(y)
+		if y < 7 {
+			fen += "/"
+		}
+	}
+
+	return fen
+}
+
+func (c *Chess) calculateRowFEN(y int) string {
+	fen := ""
+	empty := 0
+	for x := range c.board.Width() {
+		// Ignore errors since the coordinates are valid.
+		piece, _ := c.board.Square(gochess.Coor(x, y))
+
+		if piece == gochess.Empty {
+			empty++
+			continue
+		}
+
+		if empty > 0 {
+			fen += fmt.Sprintf("%d", empty)
+			empty = 0
+		}
+
+		fen += gochess.PieceNames[piece]
+	}
+
+	if empty > 0 {
+		fen += fmt.Sprintf("%d", empty)
+	}
+
+	return fen
+}
+
+// setProperties is a helper function that sets the properties of the Chess struct.
+// It verifies the properties of the FEN string.
+// It returns an error if the FEN string is invalid.
+func (c *Chess) setProperties(FEN string) error {
+	props := strings.Split(FEN, " ")[1:]
+
+	color, ok := gochess.Colors[props[0]]
+	if !ok {
+		return fmt.Errorf("invalid color: %s", props[0])
+	}
+
+	availableCastles := props[1]
+	if err := c.validateCastles(availableCastles); err != nil {
+		return fmt.Errorf("invalid castles: %s", availableCastles)
+	}
+
+	enPassantSquare := props[2]
+	if err := c.validateEnPassant(enPassantSquare); err != nil {
+		return fmt.Errorf("invalid en passant square: %s", enPassantSquare)
+	}
+
+	halfMoves, err := strconv.Atoi(props[3])
+	if err != nil {
+		return fmt.Errorf("invalid half moves: %s", props[3])
+	}
+
+	movesCount, err := strconv.ParseUint(props[4], 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid moves count: %s", props[4])
+	}
+
+	c.turn = color
+	c.availableCastles = availableCastles
+	c.enPassantSquare = props[2]
+	c.halfMoves = halfMoves
+	c.movesCount = movesCount
+	return nil
+}
+
+// updateMovesCount updates the moves count.
+func (c *Chess) updateMovesCount() {
+	if c.turn == gochess.White {
+		c.movesCount++
+	}
+}
+
+// updateCastlePossibilities checks if the castles are still available.
+func (c *Chess) updateCastlePossibilities() {
+	toBeRemoved := map[string]bool{}
+
+	k, _ := c.board.Square(gochess.Coor(4, 0))
+	rr, _ := c.board.Square(gochess.Coor(7, 0))
+	lr, _ := c.board.Square(gochess.Coor(0, 0))
+	toBeRemoved["k"] = rr != gochess.Rook|gochess.Black || k != gochess.King|gochess.Black
+	toBeRemoved["q"] = lr != gochess.Rook|gochess.Black || k != gochess.King|gochess.Black
+
+	K, _ := c.board.Square(gochess.Coor(4, 7))
+	rR, _ := c.board.Square(gochess.Coor(7, 7))
+	lR, _ := c.board.Square(gochess.Coor(0, 7))
+	toBeRemoved["K"] = rR != gochess.Rook|gochess.White || K != gochess.King|gochess.White
+	toBeRemoved["Q"] = lR != gochess.Rook|gochess.White || K != gochess.King|gochess.White
+
+	for castle, mustDelete := range toBeRemoved {
+		if !mustDelete {
+			continue
+		}
+
+		c.availableCastles = strings.ReplaceAll(c.availableCastles, castle, "")
+	}
+}
+
+// updateHalfMoves updates the half moves counter.
+//
+// It must be called after a move is made. If no move was made,
+// the function will panic.
+func (c *Chess) updateHalfMoves() {
+	c.halfMoves++
+	h := c.history[len(c.history)-1]
+
+	// If the move was promotion, reset the counter.
+	if len(h.move) == 5 {
+		c.halfMoves = 0
+		return
+	}
+
+	// Look for a change in the board.
+	// If we have less pieces than before, a capture was made so we reset the counter.
+	lastFENPiecePart := strings.Split(h.fen, " ")[0]
+
+	lastFENPiecePart = fenAnalysisRegex.ReplaceAllString(lastFENPiecePart, "")
+	fenPiecePart := fenAnalysisRegex.ReplaceAllString(c.calculateBoardFEN(), "")
+
+	if len(lastFENPiecePart) > len(fenPiecePart) {
+		c.halfMoves = 0
+		return
+	}
+
+	// If no capture was made, we check if last move was a pawn move.
+	target := h.move[2:4]
+	coor, _ := AlgebraicToCoordinate(target)
+	p, _ := c.board.Square(coor)
+
+	piece := p &^ (gochess.White | gochess.Black)
+	if piece == gochess.Pawn {
+		c.halfMoves = 0
+	}
+}
+
+// updateEnPassantSquare updates the en passant square.
+//
+// It must be called after a move is made. If no move was made,
+// the function will panic.
+func (c *Chess) updateEnPassantSquare() {
+	c.enPassantSquare = ""
+
+	lastMove := c.history[len(c.history)-1].move
+	if len(lastMove) != 4 {
+		return
+	}
+
+	dest, _ := AlgebraicToCoordinate(lastMove[2:])
+	p, _ := c.board.Square(dest)
+
+	if p&^(gochess.White|gochess.Black) != gochess.Pawn {
+		return
+	}
+
+	destRow, _ := strconv.Atoi(lastMove[3:4])
+	orgRow, _ := strconv.Atoi(lastMove[1:2])
+	if destRow == orgRow+2 || destRow == orgRow-2 {
+		c.enPassantSquare = fmt.Sprintf("%s%d", lastMove[2:3], (destRow+orgRow)/2)
+		return
+	}
+}
+
+// validateEnPassant validates the in passant square.
+func (c Chess) validateEnPassant(square string) error {
+	if square == "-" {
+		return nil
+	}
+
+	coor, err := AlgebraicToCoordinate(square)
+	if err != nil {
+		return errors.New("invalid in passant square")
+	}
+
+	if coor.Y != 2 && coor.Y != 5 {
+		return errors.New("invalid in passant square")
+	}
+
+	yCoor := 4
+	color := gochess.White
+	if coor.Y == 2 {
+		yCoor = 3
+		color = gochess.Black
+	}
+
+	auxCoor := gochess.Coor(coor.X, yCoor)
+	p, _ := c.board.Square(auxCoor)
+	if p&^color != gochess.Pawn {
+		return errors.New("invalid in passant square")
+	}
+
+	return nil
+}
+
+// validateCastles validates the castles string.
+func (Chess) validateCastles(castles string) error {
+	if castles == "-" {
+		return nil
+	}
+
+	castlePieces := map[rune]bool{'K': true, 'Q': true, 'k': true, 'q': true}
+	for _, castle := range castles {
+		if !castlePieces[castle] {
+			return errors.New("invalid castles")
+		}
+
+		delete(castlePieces, castle)
+	}
+
+	return nil
+}
+
+// isPositionLegal verifies if the current turn can capture the opponent king.
+//
+// If the current turn can capture the opponent king, the position is not legal
+// and the function returns false.
+func (c Chess) isPositionLegal() bool {
+	c.toggleColor()
+	defer c.toggleColor()
+	return !c.isCheck()
+}
+
+func (c *Chess) toggleColor() {
+	if c.turn == gochess.White {
+		c.turn = gochess.Black
+		return
+	}
+
+	c.turn = gochess.White
+}
+
+func (c Chess) isCheck() bool {
+	kingPosition := c.kingsPosition(c.turn)
+
+	c.toggleColor()
+	defer c.toggleColor()
+	moves := c.availableMoves()
+
+	return destinationMatch(moves, kingPosition)
+}
+
+// kingsPosition returns the position of the king of the given color.
+func (c Chess) kingsPosition(color int8) gochess.Coordinate {
+	if color == gochess.White {
+		return *c.whiteKingPosition
+	}
+
+	return *c.blackKingPosition
+}
+
+// pieceFromFEN is a helper function that returns the piece at the given coordinate
+// in the FEN string.
+//
+// It must be called with a valid coordinate and a valid FEN string.
+// If there is no piece at the given coordinate, it returns gochess.Empty.
+func pieceFromFEN(fen string, coord gochess.Coordinate) int8 {
+	fenRow := strings.Split(strings.Split(fen, " ")[0], "/")[coord.Y]
+	var count int
+	for _, c := range fenRow {
+		n, err := strconv.Atoi(string(c))
+		if err == nil {
+			count += n
+			if count > coord.X {
+				return gochess.Empty
+			}
+
+			continue
+		}
+
+		if count == coord.X {
+			return gochess.Pieces[string(c)]
+		}
+
+		count++
+	}
+
+	return gochess.Empty
+}

--- a/chess/adapter.go
+++ b/chess/adapter.go
@@ -1,0 +1,25 @@
+package chess
+
+import "github.com/RchrdHndrcks/gochess"
+
+// boardAdapter is an adapter for gochess.Board that implements the Board interface.
+//
+// It is used to take advantage of the parallelism implementing the Cloner interface.
+// The Cloner interface is implemented by the adapter to avoid dependencies to the
+// gochess/chess package from the gochess package.
+type boardAdapter struct {
+	*gochess.Board
+}
+
+func newBoardAdapter(board *gochess.Board) *boardAdapter {
+	return &boardAdapter{
+		Board: board,
+	}
+}
+
+// Clone implements the Cloner interface.
+func (b *boardAdapter) Clone() Board {
+	return &boardAdapter{
+		Board: b.Board.Clone(),
+	}
+}

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -1,17 +1,20 @@
 package chess
 
 import (
-	"cmp"
-	"errors"
 	"fmt"
+	"runtime"
 	"slices"
-	"strconv"
-	"strings"
 
 	"github.com/RchrdHndrcks/gochess"
 )
 
 type (
+	// Cloner is a generic interface for objects that can be cloned.
+	Cloner interface {
+		// Clone returns a clone of the object.
+		Clone() Board
+	}
+
 	// Board represents a chess board.
 	Board interface {
 		// SetSquare sets a piece in a square.
@@ -24,11 +27,17 @@ type (
 		Width() int
 	}
 
-	// gameHistory represents the history of a game.
-	gameHistory struct {
+	// config represents configurations of how the methods will work.
+	config struct {
+		// Parallelism is the number of workers to use for the moves calculation.
+		Parallelism int
+	}
+
+	// chessContext represents the history of a game.
+	chessContext struct {
 		// move is a played move.
 		move string
-		// fen is a FEN strings that represents the position after the move.
+		// fen is a FEN strings that represents the position.
 		fen string
 		// halfMove is the number of half moves since the last capture or pawn move.
 		halfMove int
@@ -36,6 +45,10 @@ type (
 		availableCastles string
 		// enPassantSquare is the square where a pawn can capture in passant.
 		enPassantSquare string
+		// whiteKingPosition is the position of the white king.
+		whiteKingPosition *gochess.Coordinate
+		// blackKingPosition is the position of the black king.
+		blackKingPosition *gochess.Coordinate
 	}
 
 	// Chess represents a Chess game.
@@ -53,8 +66,20 @@ type (
 		// availableCastles is the castles that are available.
 		// It will has the same format as the FEN castles.
 		availableCastles string
+		// moves are the available moves in the current position.
+		moves []string
+		// actualFEN is the FEN string of the current position.
+		actualFEN string
+		// blackKingPosition is the position of the black king.
+		blackKingPosition *gochess.Coordinate
+		// whiteKingPosition is the position of the white king.
+		whiteKingPosition *gochess.Coordinate
 
-		history []gameHistory
+		// config represents configurations of how the methods will work.
+		config config
+
+		// history is the history of the game.
+		history []chessContext
 	}
 )
 
@@ -82,15 +107,46 @@ var (
 )
 
 // New creates a new chess game.
+//
+// The function will up a pool of workers to maximize performance on the
+// moves calculation.
+// By default, the number of workers is twice the number of available CPUs.
+// If you are running on a container environment or you want to use the
+// sequential version, you should set this value manually using the
+// WithParallelism option.
+// The pool of workers will be used only if the board implements the Cloner
+// interface. If you are using a custom Board implementation, you should
+// implement the Cloner interface to take advantage of the parallelism.
 func New(opts ...Option) (*Chess, error) {
-	c := &Chess{}
+	c := &Chess{
+		board:            newBoardAdapter(gochess.DefaultChessBoard()),
+		turn:             gochess.White,
+		movesCount:       1,
+		halfMoves:        0,
+		enPassantSquare:  "",
+		availableCastles: "KQkq",
+		actualFEN:        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+		moves: []string{
+			"a2a3", "a2a4", "b2b3", "b2b4", "c2c3", "c2c4", "d2d3", "d2d4",
+			"e2e3", "e2e4", "f2f3", "f2f4", "g2g3", "g2g4", "h2h3", "h2h4",
+			"b1a3", "b1c3", "g1f3", "g1h3",
+		},
+		blackKingPosition: &gochess.Coordinate{X: 4, Y: 0},
+		whiteKingPosition: &gochess.Coordinate{X: 4, Y: 7},
+		config: config{
+			// To maximize performance chess uses twice the number of available
+			// CPUs. If you are running on a container environment or you want to
+			// use the sequential version, you should set this value manually.
+			Parallelism: runtime.NumCPU() * 2,
+		},
+	}
+
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
 			return nil, fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
 
-	defaultOptions(c)
 	return c, nil
 }
 
@@ -101,83 +157,12 @@ func New(opts ...Option) (*Chess, error) {
 //
 // The board and properties will not be modified if the FEN string is invalid.
 func (c *Chess) LoadPosition(FEN string) error {
-	fenRows := strings.Split(FEN, "/")
-	if len(fenRows) != 8 {
-		return fmt.Errorf("invalid FEN: %s", FEN)
+	if err := c.loadPosition(FEN); err != nil {
+		return err
 	}
 
-	props := strings.Split(fenRows[7], " ")
-	if len(props) != 6 {
-		return fmt.Errorf("invalid FEN: %s", FEN)
-	}
-
-	fenRows[7] = props[0]
-
-	var whiteKing, blackKing int
-
-	brd := [8][8]int8{}
-	for y := range 8 {
-		row := [8]int8{}
-
-		if len(fenRows[y]) == 0 || len(fenRows[y]) > 8 {
-			return fmt.Errorf("invalid FEN: %s", FEN)
-		}
-
-		for x := range 8 {
-			char := string(fenRows[y][0])
-			fenRows[y] = fenRows[y][1:]
-
-			n, err := strconv.Atoi(char)
-			// If c is not a number, it's a piece.
-			if err != nil {
-				p := gochess.Pieces[char]
-				row[x] = p
-				if p == gochess.King|gochess.White {
-					whiteKing++
-				}
-				if p == gochess.King|gochess.Black {
-					blackKing++
-				}
-				continue
-			}
-
-			// If c is a number, reduce the number of empty squares from the FEN string.
-			n--
-			if n > 0 {
-				fenRows[y] = fmt.Sprintf("%d%s", n, fenRows[y])
-			}
-		}
-
-		if fenRows[y] != "" && fenRows[y] != "0" {
-			return fmt.Errorf("invalid FEN: %s", FEN)
-		}
-
-		brd[y] = row
-	}
-
-	// If any of the kings is not in the board, the position is invalid.
-	if whiteKing != 1 || blackKing != 1 {
-		return errors.New("invalid FEN: both kings must be in the board once")
-	}
-
-	// Make a copy of the actual chess struct because if
-	// the properties are invalid or the position is invalid
-	// the struct will not be modified.
-	copy := *c
-	c.setBoard(brd)
-
-	// If the FEN is invalid, setProperties will
-	// return an error without modifying the board or the properties.
-	if err := c.setProperties(FEN); err != nil {
-		*c = copy
-		return fmt.Errorf("invalid FEN: %w", err)
-	}
-
-	if !c.isPositionLegal() {
-		*c = copy
-		return errors.New("invalid FEN: the current turn can capture the opponent king")
-	}
-
+	c.actualFEN = FEN
+	c.moves = c.legalMoves()
 	return nil
 }
 
@@ -185,165 +170,27 @@ func (c *Chess) LoadPosition(FEN string) error {
 //
 // If any of the kings is not in the board, the function returns an empty string.
 func (c *Chess) FEN() string {
-	if !c.isPositionValid() {
-		return ""
-	}
-
-	fen := ""
-	for y := range c.board.Width() {
-		empty := 0
-		for x := range c.board.Width() {
-			// Ignore errors since the coordinates are valid.
-			piece, _ := c.board.Square(gochess.Coor(x, y))
-
-			if piece == gochess.Empty {
-				empty++
-				continue
-			}
-
-			if empty > 0 {
-				fen += fmt.Sprintf("%d", empty)
-				empty = 0
-			}
-
-			fen += gochess.PieceNames[piece]
-		}
-
-		if empty > 0 {
-			fen += fmt.Sprintf("%d", empty)
-		}
-
-		if y < 7 {
-			fen += "/"
-		}
-	}
-
-	ac := cmp.Or(c.availableCastles, "-")
-	ips := cmp.Or(c.enPassantSquare, "-")
-
-	fen += fmt.Sprintf(" %s %s %s %d %d", gochess.ColorNames[c.turn], ac, ips, c.halfMoves, c.movesCount)
-	return fen
+	return c.actualFEN
 }
 
 // AvailableMoves returns the available legal moves for the current turn.
 // It returns an empty slice if position is stalemate.
 // It returns a nil slice if position is checkmate.
 func (c *Chess) AvailableMoves() []string {
-	moves := c.availableMoves()
-
-	legalMoves := []string{}
-	for _, move := range moves {
-		if c.isLegalMove(move) {
-			legalMoves = append(legalMoves, move)
-		}
-	}
-
-	// If there are no legal moves, we need to check if position is checkmate or
-	// stalemate.
-	if len(legalMoves) == 0 {
-		if c.isCheck() {
-			legalMoves = nil
-		}
-	}
-
-	return legalMoves
-}
-
-// isLegalMove is a helper function that verifies if the move is legal.
-//
-// It verifies it making the move in a temporary board and checking if the
-// king is in check or the king way is under attack in castling moves.
-func (c Chess) isLegalMove(move string) bool {
-	kingsColor := c.turn
-	c.makeMove(move)
-
-	availableMoves := c.availableMoves()
-	kingPosition := c.kingsPosition(kingsColor)
-
-	kingUnderAttack := destinationMatch(availableMoves, kingPosition)
-
-	c.unmakeMove()
-	kingWayUnderAttack := false
-	if c.isCastleMove(move) {
-		kingWayUnderAttack = destinationMatch(availableMoves, castleKingWay[move])
-	}
-
-	return !kingUnderAttack && !kingWayUnderAttack
+	return c.moves
 }
 
 // MakeMove checks if the move is legal and makes it.
 // It returns an error if the move is not legal.
 func (c *Chess) MakeMove(move string) error {
-	moves := c.AvailableMoves()
-
-	if !slices.Contains(moves, move) {
+	if !slices.Contains(c.moves, move) {
 		return fmt.Errorf("move is not legal: %s", move)
 	}
 
 	c.makeMove(move)
+	c.actualFEN = c.calculateFEN(move)
+	c.moves = c.legalMoves()
 	return nil
-}
-
-// makeMove makes a move without checking if it is legal.
-func (c *Chess) makeMove(move string) {
-	lastFEN := c.FEN()
-
-	// Ignore the error because the move should be already validated.
-	o, _ := AlgebraicToCoordinate(move[:2])
-	t, _ := AlgebraicToCoordinate(move[2:4])
-
-	if c.isCastleMove(move) {
-		// If the move is a castle move, we need to move the rook too.
-		rookOrigin := castleRook[move]
-		rookTarget := gochess.Coor((o.X+t.X)/2, o.Y)
-
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
-		_ = c.board.MakeMove(rookOrigin, rookTarget)
-	}
-
-	if c.isEnPassantMove(move) {
-		// If the move is an en passant capture, we need to remove the captured pawn.
-		// The captured pawn is behind the target square.
-		behindTarget := gochess.Coor(t.X, o.Y)
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
-		_ = c.board.SetSquare(behindTarget, gochess.Empty)
-	}
-
-	var madeMove bool
-	// UCI moves only permit 5 characters if the move is a pawn coronation.
-	isPromotion := len(move) == 5
-	if isPromotion {
-		p := gochess.PiecesWithoutColor[move[4:5]]
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
-		_ = c.board.SetSquare(t, p|c.turn)
-		_ = c.board.SetSquare(o, gochess.Empty)
-		madeMove = true
-	}
-
-	if !madeMove {
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
-		_ = c.board.MakeMove(o, t)
-	}
-
-	c.history = append(
-		c.history,
-		gameHistory{
-			move:             move,
-			fen:              lastFEN,
-			halfMove:         c.halfMoves,
-			availableCastles: c.availableCastles,
-		},
-	)
-
-	c.toggleColor()
-	c.updateMovesCount()
-	c.updateCastlePossibilities()
-	c.updateHalfMoves()
-	c.updateInPassantSquare()
 }
 
 // UnmakeMove unmake the last move.
@@ -352,35 +199,15 @@ func (c *Chess) makeMove(move string) {
 // If there are no moves in the history, the function does nothing.
 func (c *Chess) UnmakeMove() {
 	c.unmakeMove()
-}
-
-// unmakeMove is a helper function to unmake the last move.
-func (c *Chess) unmakeMove() {
-	if len(c.history) == 0 {
-		return
-	}
-
-	lastMove := c.history[len(c.history)-1]
-	c.history = c.history[:len(c.history)-1]
-
-	lastFEN := lastMove.fen
-
-	// Ignore the error because the FEN is valid since it was on the board.
-	_ = c.LoadPosition(lastFEN)
-
-	c.halfMoves = lastMove.halfMove
-	c.availableCastles = lastMove.availableCastles
-	c.enPassantSquare = lastMove.enPassantSquare
-
-	// If turn color is white, last move was black.
-	// So we decrease the moves count.
-	if c.turn == gochess.White && c.movesCount > 1 {
-		c.movesCount--
-	}
+	c.moves = c.legalMoves()
 }
 
 // IsCheck returns if the current turn is in check.
 func (c *Chess) IsCheck() bool {
+	if c.blackKingPosition == nil || c.whiteKingPosition == nil {
+		return false
+	}
+
 	return c.isCheck()
 }
 
@@ -388,7 +215,7 @@ func (c *Chess) IsCheck() bool {
 // The square is represented by an algebraic notation.
 //
 // If the square is not valid, the function returns an error.
-func (c Chess) Square(square string) (string, error) {
+func (c *Chess) Square(square string) (string, error) {
 	coor, err := AlgebraicToCoordinate(square)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert algebraic notation to coordinate: %w", err)
@@ -400,582 +227,45 @@ func (c Chess) Square(square string) (string, error) {
 	return gochess.PieceNames[p], nil
 }
 
-// setBoard is a helper function that sets the board with a 2D array of pieces.
-// The array should have 8 rows and 8 columns.
-// The pieces are not validated.
-func (c *Chess) setBoard(rows [8][8]int8) {
-	for y := range 8 {
-		for x := range 8 {
-			c.board.SetSquare(gochess.Coor(x, y), rows[y][x])
-		}
-	}
-}
+// clone creates a deep copy of the Chess structure.
+func (c Chess) clone() Chess {
+	cloned := c
 
-// setProperties is a helper function that sets the properties of the Chess struct.
-// It verifies the properties of the FEN string.
-// It returns an error if the FEN string is invalid.
-func (c *Chess) setProperties(FEN string) error {
-	props := strings.Split(FEN, " ")[1:]
-
-	color, ok := gochess.Colors[props[0]]
-	if !ok {
-		return fmt.Errorf("invalid color: %s", props[0])
+	cloner, ok := c.board.(Cloner)
+	if ok {
+		cloned.board = cloner.Clone()
 	}
 
-	availableCastles := props[1]
-	if err := c.validateCastles(availableCastles); err != nil {
-		return fmt.Errorf("invalid castles: %s", availableCastles)
+	if c.whiteKingPosition != nil {
+		whitePos := *c.whiteKingPosition
+		cloned.whiteKingPosition = &whitePos
+	}
+	if c.blackKingPosition != nil {
+		blackPos := *c.blackKingPosition
+		cloned.blackKingPosition = &blackPos
 	}
 
-	enPassantSquare := props[2]
-	if err := c.validateInPassant(enPassantSquare); err != nil {
-		return fmt.Errorf("invalid en passant square: %s", enPassantSquare)
-	}
-
-	halfMoves, err := strconv.Atoi(props[3])
-	if err != nil {
-		return fmt.Errorf("invalid half moves: %s", props[3])
-	}
-
-	movesCount, err := strconv.ParseUint(props[4], 10, 32)
-	if err != nil {
-		return fmt.Errorf("invalid moves count: %s", props[4])
-	}
-
-	c.turn = color
-	c.availableCastles = availableCastles
-	c.enPassantSquare = props[2]
-	c.halfMoves = halfMoves
-	c.movesCount = movesCount
-	return nil
-}
-
-// kingsPosition returns the position of the king of the given color.
-func (c Chess) kingsPosition(color int8) gochess.Coordinate {
-	coor := gochess.Coordinate{}
-	for y := range c.board.Width() {
-		for x := range c.board.Width() {
-			piece, _ := c.board.Square(gochess.Coor(x, y))
-			if piece == gochess.King|color {
-				coor = gochess.Coor(x, y)
-				break
+	if len(c.history) > 0 {
+		cloned.history = make([]chessContext, len(c.history))
+		for i, ctx := range c.history {
+			cloned.history[i] = ctx
+			if ctx.whiteKingPosition != nil {
+				whitePos := *ctx.whiteKingPosition
+				cloned.history[i].whiteKingPosition = &whitePos
+			}
+			if ctx.blackKingPosition != nil {
+				blackPos := *ctx.blackKingPosition
+				cloned.history[i].blackKingPosition = &blackPos
 			}
 		}
+	} else {
+		cloned.history = nil
 	}
 
-	return coor
-}
-
-func (c Chess) isCheck() bool {
-	kingPosition := c.kingsPosition(c.turn)
-
-	c.toggleColor()
-	defer c.toggleColor()
-	moves := c.availableMoves()
-
-	return destinationMatch(moves, kingPosition)
-}
-
-func (c *Chess) toggleColor() {
-	if c.turn == gochess.White {
-		c.turn = gochess.Black
-		return
+	if len(c.moves) > 0 {
+		cloned.moves = make([]string, len(c.moves))
+		copy(cloned.moves, c.moves)
 	}
 
-	c.turn = gochess.White
-}
-
-func (c *Chess) updateMovesCount() {
-	if c.turn == gochess.White {
-		c.movesCount++
-	}
-}
-
-// updateCastlePossibilities checks if the castles are still available.
-func (c *Chess) updateCastlePossibilities() {
-	toBeRemoved := map[string]bool{}
-
-	k, _ := c.board.Square(gochess.Coor(4, 0))
-	rr, _ := c.board.Square(gochess.Coor(7, 0))
-	lr, _ := c.board.Square(gochess.Coor(0, 0))
-	toBeRemoved["k"] = rr != gochess.Rook|gochess.Black || k != gochess.King|gochess.Black
-	toBeRemoved["q"] = lr != gochess.Rook|gochess.Black || k != gochess.King|gochess.Black
-
-	K, _ := c.board.Square(gochess.Coor(4, 7))
-	rR, _ := c.board.Square(gochess.Coor(7, 7))
-	lR, _ := c.board.Square(gochess.Coor(0, 7))
-	toBeRemoved["K"] = rR != gochess.Rook|gochess.White || K != gochess.King|gochess.White
-	toBeRemoved["Q"] = lR != gochess.Rook|gochess.White || K != gochess.King|gochess.White
-
-	for castle, mustDelete := range toBeRemoved {
-		if !mustDelete {
-			continue
-		}
-
-		c.availableCastles = strings.ReplaceAll(c.availableCastles, castle, "")
-	}
-}
-
-// updateHalfMoves updates the half moves counter.
-//
-// It must be called after a move is made. If no move was made,
-// the function will panic.
-func (c *Chess) updateHalfMoves() {
-	c.halfMoves++
-
-	// First we look for a change in the board.
-	// If we have less pieces than before, a capture was made so we reset the counter.
-	h := c.history[len(c.history)-1]
-	aux, _ := New(WithFEN(h.fen))
-	piecesCount := 0
-	auxPiecesCount := 0
-	for y := range c.board.Width() {
-		for x := range c.board.Width() {
-			piece, _ := c.board.Square(gochess.Coor(x, y))
-			auxPiece, _ := aux.board.Square(gochess.Coor(x, y))
-			if piece != gochess.Empty {
-				piecesCount++
-			}
-
-			if auxPiece != gochess.Empty {
-				auxPiecesCount++
-			}
-		}
-	}
-
-	if piecesCount != auxPiecesCount {
-		c.halfMoves = 0
-		return
-	}
-
-	// If no capture was made, we check if last move was a pawn move.
-	origin := h.move[:2]
-	coor, _ := AlgebraicToCoordinate(origin)
-	p, _ := aux.board.Square(coor)
-
-	piece := p &^ (gochess.White | gochess.Black)
-	if piece == gochess.Pawn {
-		c.halfMoves = 0
-	}
-}
-
-// updateInPassantSquare updates the en passant square.
-//
-// It must be called after a move is made. If no move was made,
-// the function will panic.
-func (c *Chess) updateInPassantSquare() {
-	c.enPassantSquare = ""
-
-	lastMove := c.history[len(c.history)-1].move
-	if len(lastMove) != 4 {
-		return
-	}
-
-	dest, _ := AlgebraicToCoordinate(lastMove[2:])
-	p, _ := c.board.Square(dest)
-
-	if p&^(gochess.White|gochess.Black) != gochess.Pawn {
-		return
-	}
-
-	destRow, _ := strconv.Atoi(lastMove[3:4])
-	orgRow, _ := strconv.Atoi(lastMove[1:2])
-	if destRow == orgRow+2 || destRow == orgRow-2 {
-		c.enPassantSquare = fmt.Sprintf("%s%d", lastMove[2:3], (destRow+orgRow)/2)
-		return
-	}
-}
-
-// isCastleMove returns if the move is a castle move.
-//
-// The passed move must be valid.
-func (c Chess) isCastleMove(move string) bool {
-	if castlesMoves[move] != c.turn {
-		return false
-	}
-
-	origin, _ := AlgebraicToCoordinate(move[:2])
-	p, _ := c.board.Square(origin)
-
-	return p == gochess.King|c.turn
-}
-
-// isEnPassantMove returns if the move is an en passant capture move.
-//
-// The passed move must be valid.
-func (c Chess) isEnPassantMove(move string) bool {
-	if c.enPassantSquare == "" {
-		return false
-	}
-
-	origin, _ := AlgebraicToCoordinate(move[:2])
-
-	if move[2:4] != c.enPassantSquare {
-		return false
-	}
-
-	p, _ := c.board.Square(origin)
-	return p&^(gochess.White|gochess.Black) == gochess.Pawn
-}
-
-// isPositionValid checks if both kings are in the board once.
-func (c Chess) isPositionValid() bool {
-	var whiteKings, blackKings int
-	for y := range c.board.Width() {
-		for x := range c.board.Width() {
-			piece, _ := c.board.Square(gochess.Coor(x, y))
-
-			if piece == gochess.King|gochess.White {
-				whiteKings++
-			}
-
-			if piece == gochess.King|gochess.Black {
-				blackKings++
-			}
-		}
-	}
-
-	return whiteKings == 1 && blackKings == 1
-}
-
-// isPositionLegal verifies if the current turn can capture the opponent king.
-//
-// If the current turn can capture the opponent king, the position is not legal
-// and the function returns false.
-func (c Chess) isPositionLegal() bool {
-	c.toggleColor()
-	return !c.isCheck()
-}
-
-// validateCastles validates the castles string.
-func (Chess) validateCastles(castles string) error {
-	if castles == "-" {
-		return nil
-	}
-
-	castlePieces := map[rune]bool{'K': true, 'Q': true, 'k': true, 'q': true}
-	for _, castle := range castles {
-		if !castlePieces[castle] {
-			return errors.New("invalid castles")
-		}
-
-		delete(castlePieces, castle)
-	}
-
-	return nil
-}
-
-// validateInPassant validates the in passant square.
-func (c Chess) validateInPassant(square string) error {
-	if square == "-" {
-		return nil
-	}
-
-	coor, err := AlgebraicToCoordinate(square)
-	if err != nil {
-		return errors.New("invalid in passant square")
-	}
-
-	if coor.Y != 2 && coor.Y != 5 {
-		return errors.New("invalid in passant square")
-	}
-
-	yCoor := 4
-	color := gochess.White
-	if coor.Y == 2 {
-		yCoor = 3
-		color = gochess.Black
-	}
-
-	auxCoor := gochess.Coor(coor.X, yCoor)
-	p, _ := c.board.Square(auxCoor)
-	if p&^color != gochess.Pawn {
-		return errors.New("invalid in passant square")
-	}
-
-	return nil
-}
-
-// destinationMatch looks for a destination in a list of moves.
-// It returns true if any of the moves has the destination.
-// The function expects the moves in UCI format.
-func destinationMatch(moves []string, destination gochess.Coordinate) bool {
-	algCoor := CoordinateToAlgebraic(destination)
-	for _, move := range moves {
-		dest := move[2:4]
-		if dest == algCoor {
-			return true
-		}
-	}
-
-	return false
-}
-
-// availableMoves returns the available moves for the current turn without checking if they are legal.
-func (c *Chess) availableMoves() []string {
-	moves := []string{}
-	for x := range 8 {
-		for y := range 8 {
-			origin := gochess.Coor(x, y)
-			piece, _ := c.board.Square(origin)
-			if piece&c.turn == gochess.Empty {
-				continue
-			}
-
-			moves = append(moves, c.movesForPiece(piece, origin)...)
-		}
-	}
-
-	return moves
-}
-
-// movesForPiece returns the available moves for a piece.
-//
-// The function returns a slice of UCI moves.
-// (e.g. "e2e4" for moving the piece at e2 to e4.)
-// Disclaimer: This function does not check if the move is legal for a Chess game.
-func (c Chess) movesForPiece(piece int8, origin gochess.Coordinate) []string {
-	switch piece &^ (gochess.White | gochess.Black) {
-	case gochess.Pawn:
-		return c.pawnMoves(origin)
-	case gochess.Rook:
-		return c.rookMoves(origin)
-	case gochess.Queen:
-		return c.queenMoves(origin)
-	case gochess.King:
-		return append(c.kingMoves(origin), c.kingCastleMoves(origin)...)
-	case gochess.Bishop:
-		return c.bishopMoves(origin)
-	case gochess.Knight:
-		return c.knightMoves(origin)
-	}
-
-	return nil
-}
-
-// pawnMoves returns all the valid pawn moves.
-func (c Chess) pawnMoves(origin gochess.Coordinate) []string {
-	p, _ := c.board.Square(origin)
-	dir := -1
-	if p&gochess.White == gochess.Empty {
-		dir = 1
-	}
-
-	isPromotion := false
-	tCor := gochess.Coor(origin.X, origin.Y+1*dir)
-	if tCor.Y == 7 || tCor.Y == 0 {
-		isPromotion = true
-	}
-
-	moves := make([]string, 0, 2)
-	s, _ := c.board.Square(tCor)
-	if s == gochess.Empty {
-		moves = append(moves, UCI(origin, tCor))
-	}
-
-	if isPromotion {
-		return append(c.pawnCaptureMoves(origin, true), c.promotionPosibilities(origin, tCor)...)
-	}
-
-	if !(dir == 1 && origin.Y == 1) && !(dir == -1 && origin.Y == 6) {
-		return append(c.pawnCaptureMoves(origin, false), moves...)
-	}
-
-	tCor = gochess.Coor(origin.X, origin.Y+2*dir)
-	s, _ = c.board.Square(tCor)
-	if s == gochess.Empty {
-		moves = append(moves, UCI(origin, tCor))
-	}
-
-	return append(c.pawnCaptureMoves(origin, false), moves...)
-}
-
-// pawnCaptureMoves returns all the valid pawn capture moves.
-func (c Chess) pawnCaptureMoves(origin gochess.Coordinate, isPromotion bool) []string {
-	p, _ := c.board.Square(origin)
-	pColor := p & (gochess.White | gochess.Black)
-	dir := -1
-	if pColor == gochess.Black {
-		dir = 1
-	}
-
-	moves := []string{}
-	offsets := []int{-1, 1}
-	for _, o := range offsets {
-		tCor := gochess.Coor(origin.X+o, origin.Y+1*dir)
-		if tCor.X < 0 || tCor.X > 7 || tCor.Y < 0 || tCor.Y > 7 {
-			continue
-		}
-
-		if CoordinateToAlgebraic(tCor) == c.enPassantSquare {
-			moves = append(moves, UCI(origin, tCor))
-			continue
-		}
-
-		ts, _ := c.board.Square(tCor)
-		if ts == gochess.Empty || ts&pColor != gochess.Empty {
-			continue
-		}
-
-		if !isPromotion {
-			moves = append(moves, UCI(origin, tCor))
-			continue
-		}
-
-		moves = append(moves, c.promotionPosibilities(origin, tCor)...)
-	}
-
-	return moves
-}
-
-// promotionPosibilities is a helper function that returns the UCI moves with
-// the value of the piece to be promoted.
-func (c Chess) promotionPosibilities(origin, target gochess.Coordinate) []string {
-	moves := make([]string, 4)
-	for i, p := range []int8{gochess.Queen, gochess.Rook, gochess.Bishop, gochess.Knight} {
-		moves[i] = UCI(origin, target, p)
-	}
-
-	return moves
-}
-
-// knightMoves returns valid knight moves.
-func (c Chess) knightMoves(origin gochess.Coordinate) []string {
-	offsets := []gochess.Coordinate{
-		{X: 1, Y: 2}, {X: 2, Y: 1},
-		{X: 1, Y: -2}, {X: 2, Y: -1},
-		{X: -1, Y: 2}, {X: -2, Y: 1},
-		{X: -1, Y: -2}, {X: -2, Y: -1},
-	}
-
-	return c.oneStepPieces(origin, offsets)
-}
-
-// kingMoves returns valid king moves.
-func (c Chess) kingMoves(origin gochess.Coordinate) []string {
-	offsets := []gochess.Coordinate{
-		{X: 1, Y: 1}, {X: 1, Y: 0}, {X: 1, Y: -1},
-		{X: 0, Y: 1}, {X: 0, Y: -1},
-		{X: -1, Y: 1}, {X: -1, Y: 0}, {X: -1, Y: -1},
-	}
-
-	return c.oneStepPieces(origin, offsets)
-}
-
-// kingCastleMoves returns valid castle moves.
-func (c Chess) kingCastleMoves(origin gochess.Coordinate) []string {
-	if c.availableCastles == "-" {
-		return nil
-	}
-
-	p, _ := c.board.Square(origin)
-	kingColor := p & (gochess.White | gochess.Black)
-
-	castleDirections := map[string]int{
-		"k": 1, "K": 1,
-		"q": -1, "Q": -1,
-	}
-
-	moves := []string{}
-	for castle, dir := range castleDirections {
-		if !strings.Contains(c.availableCastles, castle) {
-			continue
-		}
-
-		if gochess.Pieces[castle]&kingColor == gochess.Empty {
-			continue
-		}
-
-		ts, err := c.board.Square(gochess.Coor(origin.X+dir, origin.Y))
-		if err != nil || ts != gochess.Empty {
-			continue
-		}
-
-		ts, err = c.board.Square(gochess.Coor(origin.X+2*dir, origin.Y))
-		if err != nil || ts != gochess.Empty {
-			continue
-		}
-
-		moves = append(moves, UCI(origin, gochess.Coor(origin.X+2*dir, origin.Y)))
-
-		if len(moves) == 2 {
-			break
-		}
-	}
-
-	return moves
-}
-
-// rookMoves returns valid rook moves.
-func (c Chess) rookMoves(origin gochess.Coordinate) []string {
-	offsets := []gochess.Coordinate{{X: 1, Y: 0}, {X: -1, Y: 0}, {X: 0, Y: 1}, {X: 0, Y: -1}}
-	return c.slidingPieces(origin, offsets)
-}
-
-// bishopMoves returns valid bishop moves.
-func (c Chess) bishopMoves(origin gochess.Coordinate) []string {
-	offsets := []gochess.Coordinate{{X: 1, Y: 1}, {X: -1, Y: 1}, {X: 1, Y: -1}, {X: -1, Y: -1}}
-	return c.slidingPieces(origin, offsets)
-}
-
-// queenMoves returns valid queen moves.
-func (c Chess) queenMoves(origin gochess.Coordinate) []string {
-	return append(c.rookMoves(origin), c.bishopMoves(origin)...)
-}
-
-// slidingPieces returns valid moves for sliding pieces.
-func (c Chess) slidingPieces(origin gochess.Coordinate, offsets []gochess.Coordinate) []string {
-	p, _ := c.board.Square(origin)
-
-	color := p & (gochess.White | gochess.Black)
-	moves := []string{}
-	for _, d := range offsets {
-		for i := 1; ; i++ {
-			tCor := gochess.Coor(origin.X+i*d.X, origin.Y+i*d.Y)
-			ts, err := c.board.Square(tCor)
-			if err != nil {
-				break
-			}
-
-			if ts == gochess.Empty {
-				moves = append(moves, UCI(origin, tCor))
-				continue
-			}
-
-			if ts&color == gochess.Empty {
-				moves = append(moves, UCI(origin, tCor))
-				break
-			}
-
-			// If the piece is the same color, stop looking in that direction.
-			break
-		}
-	}
-
-	return moves
-}
-
-func (c Chess) oneStepPieces(origin gochess.Coordinate, offsets []gochess.Coordinate) []string {
-	p, _ := c.board.Square(origin)
-
-	color := p & (gochess.White | gochess.Black)
-	moves := []string{}
-	for _, d := range offsets {
-		tCor := gochess.Coor(origin.X+d.X, origin.Y+d.Y)
-		ts, err := c.board.Square(tCor)
-		if err != nil {
-			continue
-		}
-
-		if ts == gochess.Empty {
-			moves = append(moves, UCI(origin, tCor))
-			continue
-		}
-
-		if ts&color == gochess.Empty {
-			moves = append(moves, UCI(origin, tCor))
-		}
-	}
-
-	return moves
+	return cloned
 }

--- a/chess/chess_benchmark_test.go
+++ b/chess/chess_benchmark_test.go
@@ -1,0 +1,72 @@
+package chess_test
+
+import (
+	"testing"
+
+	"github.com/RchrdHndrcks/gochess/chess"
+)
+
+func BenchmarkCapablancaSteiner(b *testing.B) {
+	b.ResetTimer()
+
+	for b.Loop() {
+		// Arrange
+		c, err := chess.New()
+		if err != nil {
+			b.Fatalf("Error creating new chess game: %v", err)
+		}
+
+		// Act
+		moves := []string{
+			"e2e4", "e7e5", "g1f3", "b8c6", "b1c3", "g8f6", "f1b5", "f8b4",
+			"e1g1", "e8g8", "d2d3", "d7d6", "c1g5", "b4c3", "b2c3", "c6e7",
+			"f3h4", "c7c6", "b5c4", "c8e6", "g5f6", "g7f6", "c4e6", "f7e6",
+			"d1g4", "g8f7", "f2f4", "f8g8", "g4h5", "f7g7", "f4e5", "d6e5",
+			"f1f6", "g7f6", "a1f1", "e7f5", "h4f5", "e6f5", "f1f5", "f6e7",
+			"h5f7", "e7d6", "f5f6", "d6c5", "f7b7", "d8b6", "f6c6", "b6c6",
+			"b7b4",
+		}
+
+		for _, move := range moves {
+			err = c.MakeMove(move)
+			if err != nil {
+				b.Fatalf("Error making move %s: %v", move, err)
+			}
+		}
+
+		if c.FEN() != "r5r1/p6p/2q5/2k1p3/1Q2P3/2PP4/P1P3PP/6K1 b - - 1 25" {
+			b.Fatalf("Unexpected final position: %s", c.FEN())
+		}
+
+		if c.AvailableMoves() != nil {
+			b.Fatalf("Expected no legal moves, but got some")
+		}
+	}
+}
+
+func BenchmarkVariousMoves(b *testing.B) {
+	moves := []string{
+		"e2e4", "e7e5", "g1f3", "b8c6", "b1c3", "g8f6", "f1b5", "f8b4",
+		"e1g1", "e8g8", "d2d3", "d7d6", "c1g5", "b4c3", "b2c3", "c6e7",
+		"f3h4", "c7c6", "b5c4", "c8e6", "g5f6", "g7f6", "c4e6", "f7e6",
+		"d1g4", "g8f7", "f2f4", "f8g8", "g4h5", "f7g7", "f4e5", "d6e5",
+		"f1f6", "g7f6", "a1f1", "e7f5", "h4f5", "e6f5", "f1f5", "f6e7",
+		"h5f7", "e7d6", "f5f6", "d6c5", "f7b7", "d8b6", "f6c6", "b6c6",
+		"b7b4",
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		c, err := chess.New()
+		if err != nil {
+			b.Fatalf("Error creating new chess game: %v", err)
+		}
+
+		for _, move := range moves {
+			err = c.MakeMove(move)
+			if err != nil {
+				b.Fatalf("Error making move %s: %v", move, err)
+			}
+		}
+	}
+}

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -292,14 +292,6 @@ func TestFEN(t *testing.T) {
 		// Assert
 		require.Equal(t, "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", fen)
 	})
-
-	t.Run("Manual created Chess - Empty board", func(t *testing.T) {
-		// Arrange
-		c := chess.Chess{}
-
-		// Act
-		assert.Panics(t, func() { c.FEN() })
-	})
 }
 
 func TestMakeMove(t *testing.T) {
@@ -565,8 +557,7 @@ func TestMakeMove_ScholarMate(t *testing.T) {
 
 	// Assert
 	require.Nil(t, err)
-	assert.Equal(t, "r1bqkb1r/pppp1Qpp/2n2n2/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4",
-		c.FEN())
+	assert.Equal(t, "r1bqkb1r/pppp1Qpp/2n2n2/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4", c.FEN())
 }
 
 func TestMakeMove_CapablancaSteiner(t *testing.T) {
@@ -574,111 +565,24 @@ func TestMakeMove_CapablancaSteiner(t *testing.T) {
 	c, err := chess.New()
 	require.Nil(t, err)
 
-	// Act
-	err = c.MakeMove("e2e4")
-	require.Nil(t, err)
-	err = c.MakeMove("e7e5")
-	require.Nil(t, err)
-	err = c.MakeMove("g1f3")
-	require.Nil(t, err)
-	err = c.MakeMove("b8c6")
-	require.Nil(t, err)
-	err = c.MakeMove("b1c3")
-	require.Nil(t, err)
-	err = c.MakeMove("g8f6")
-	require.Nil(t, err)
-	err = c.MakeMove("f1b5")
-	require.Nil(t, err)
-	err = c.MakeMove("f8b4")
-	require.Nil(t, err)
-	err = c.MakeMove("e1g1")
-	require.Nil(t, err)
-	err = c.MakeMove("e8g8")
-	require.Nil(t, err)
-	err = c.MakeMove("d2d3")
-	require.Nil(t, err)
-	err = c.MakeMove("d7d6")
-	require.Nil(t, err)
-	err = c.MakeMove("c1g5")
-	require.Nil(t, err)
-	err = c.MakeMove("b4c3")
-	require.Nil(t, err)
-	err = c.MakeMove("b2c3")
-	require.Nil(t, err)
-	err = c.MakeMove("c6e7")
-	require.Nil(t, err)
-	err = c.MakeMove("f3h4")
-	require.Nil(t, err)
-	err = c.MakeMove("c7c6")
-	require.Nil(t, err)
-	err = c.MakeMove("b5c4")
-	require.Nil(t, err)
-	err = c.MakeMove("c8e6")
-	require.Nil(t, err)
-	err = c.MakeMove("g5f6")
-	require.Nil(t, err)
-	err = c.MakeMove("g7f6")
-	require.Nil(t, err)
-	err = c.MakeMove("c4e6")
-	require.Nil(t, err)
-	err = c.MakeMove("f7e6")
-	require.Nil(t, err)
-	err = c.MakeMove("d1g4")
-	require.Nil(t, err)
-	err = c.MakeMove("g8f7")
-	require.Nil(t, err)
-	err = c.MakeMove("f2f4")
-	require.Nil(t, err)
-	err = c.MakeMove("f8g8")
-	require.Nil(t, err)
-	err = c.MakeMove("g4h5")
-	require.Nil(t, err)
-	err = c.MakeMove("f7g7")
-	require.Nil(t, err)
-	err = c.MakeMove("f4e5")
-	require.Nil(t, err)
-	err = c.MakeMove("d6e5")
-	require.Nil(t, err)
-	err = c.MakeMove("f1f6")
-	require.Nil(t, err)
-	err = c.MakeMove("g7f6")
-	require.Nil(t, err)
-	err = c.MakeMove("a1f1")
-	require.Nil(t, err)
-	err = c.MakeMove("e7f5")
-	require.Nil(t, err)
-	err = c.MakeMove("h4f5")
-	require.Nil(t, err)
-	err = c.MakeMove("e6f5")
-	require.Nil(t, err)
-	err = c.MakeMove("f1f5")
-	require.Nil(t, err)
-	err = c.MakeMove("f6e7")
-	require.Nil(t, err)
-	err = c.MakeMove("h5f7")
-	require.Nil(t, err)
-	err = c.MakeMove("e7d6")
-	require.Nil(t, err)
-	err = c.MakeMove("f5f6")
-	require.Nil(t, err)
-	err = c.MakeMove("d6c5")
-	require.Nil(t, err)
-	err = c.MakeMove("f7b7")
-	require.Nil(t, err)
-	err = c.MakeMove("d8b6")
-	require.Nil(t, err)
-	err = c.MakeMove("f6c6")
-	require.Nil(t, err)
-	err = c.MakeMove("b6c6")
-	require.Nil(t, err)
-	err = c.MakeMove("b7b4")
-	require.Nil(t, err)
+	moves := []string{
+		"e2e4", "e7e5", "g1f3", "b8c6", "b1c3", "g8f6", "f1b5", "f8b4",
+		"e1g1", "e8g8", "d2d3", "d7d6", "c1g5", "b4c3", "b2c3", "c6e7",
+		"f3h4", "c7c6", "b5c4", "c8e6", "g5f6", "g7f6", "c4e6", "f7e6",
+		"d1g4", "g8f7", "f2f4", "f8g8", "g4h5", "f7g7", "f4e5", "d6e5",
+		"f1f6", "g7f6", "a1f1", "e7f5", "h4f5", "e6f5", "f1f5", "f6e7",
+		"h5f7", "e7d6", "f5f6", "d6c5", "f7b7", "d8b6", "f6c6", "b6c6",
+		"b7b4",
+	}
 
-	legalMoves := c.AvailableMoves()
+	// Act
+	for _, move := range moves {
+		err = c.MakeMove(move)
+		require.Nil(t, err)
+	}
 
 	// Assert
 	assert.Equal(t, "r5r1/p6p/2q5/2k1p3/1Q2P3/2PP4/P1P3PP/6K1 b - - 1 25", c.FEN())
-	assert.Nil(t, legalMoves)
 }
 
 func TestLoadPosition_Errors(t *testing.T) {

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -1,0 +1,555 @@
+package chess
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/RchrdHndrcks/gochess"
+)
+
+// capacityByPiece is a helper map where the key is the piece and the value is
+// the max moves count for that piece. It is useful to know which capacity asign
+// to the slice where the moves of these pieces are stored.
+var capacityByPiece = map[int8]int{
+	gochess.White | gochess.Queen:  27,
+	gochess.Black | gochess.Queen:  27,
+	gochess.White | gochess.Rook:   14,
+	gochess.Black | gochess.Rook:   14,
+	gochess.White | gochess.Bishop: 13,
+	gochess.Black | gochess.Bishop: 13,
+}
+
+// makeMove makes a move without checking if it is legal.
+func (c *Chess) makeMove(move string) {
+	lastFEN := c.actualFEN
+
+	// Ignore the error because the move should be already validated.
+	o, _ := AlgebraicToCoordinate(move[:2])
+	t, _ := AlgebraicToCoordinate(move[2:4])
+
+	if c.isCastleMove(move) {
+		// If the move is a castle move, we need to move the rook too.
+		//
+		// Ignore the error because the coordinates is valid because
+		// the move is already validated.
+		_ = c.board.MakeMove(castleRook[move], gochess.Coor((o.X+t.X)/2, o.Y))
+	}
+
+	if c.isEnPassantMove(move) {
+		// If the move is an en passant capture, we need to remove the captured pawn.
+		// The captured pawn is behind the target square.
+		//
+		// Ignore the error because the coordinates is valid because
+		// the move is already validated.
+		_ = c.board.SetSquare(gochess.Coor(t.X, o.Y), gochess.Empty)
+	}
+
+	// UCI moves only permit 5 characters if the move is a pawn coronation.
+	if len(move) == 5 {
+		// Ignore the error because the coordinates is valid because
+		// the move is already validated.
+		_ = c.board.SetSquare(t, gochess.PiecesWithoutColor[move[4:5]]|c.turn)
+		_ = c.board.SetSquare(o, gochess.Empty)
+	} else {
+		// Ignore the error because the coordinates is valid because
+		// the move is already validated.
+		_ = c.board.MakeMove(o, t)
+	}
+
+	c.history = append(
+		c.history,
+		chessContext{
+			move:              move,
+			fen:               lastFEN,
+			halfMove:          c.halfMoves,
+			availableCastles:  c.availableCastles,
+			enPassantSquare:   c.enPassantSquare,
+			whiteKingPosition: c.whiteKingPosition,
+			blackKingPosition: c.blackKingPosition,
+		},
+	)
+
+	// If the origin is the king, update the king position.
+	if o == *c.whiteKingPosition {
+		c.whiteKingPosition = &t
+	}
+
+	if o == *c.blackKingPosition {
+		c.blackKingPosition = &t
+	}
+
+	c.toggleColor()
+	c.updateMovesCount()
+	c.updateCastlePossibilities()
+	c.updateHalfMoves()
+	c.updateEnPassantSquare()
+}
+
+// unmakeMove is a helper function to unmake the last move.
+//
+// Until v1.1.0 unmakeMove was just reloading the last FEN from the history.
+// Now it makes the move back to the board. This change was made because
+// makeMove modifies the current board and unmakeMove was just modifying
+// the board reference.
+func (c *Chess) unmakeMove() {
+	if len(c.history) == 0 {
+		return
+	}
+
+	lastContext := c.history[len(c.history)-1]
+	c.history = c.history[:len(c.history)-1]
+
+	c.halfMoves = lastContext.halfMove
+	c.availableCastles = lastContext.availableCastles
+	c.enPassantSquare = lastContext.enPassantSquare
+	c.whiteKingPosition = lastContext.whiteKingPosition
+	c.blackKingPosition = lastContext.blackKingPosition
+	c.actualFEN = lastContext.fen
+
+	c.toggleColor()
+
+	if c.turn == gochess.Black {
+		c.movesCount--
+	}
+
+	move := lastContext.move
+	o, _ := AlgebraicToCoordinate(move[2:4])
+	t, _ := AlgebraicToCoordinate(move[:2])
+
+	// If it was a promotion, restore the captured piece.
+	if len(move) == 5 {
+		_ = c.board.SetSquare(t, gochess.Pawn|c.turn)
+	} else {
+		// Move the piece back to its original position
+		_ = c.board.MakeMove(o, t)
+	}
+
+	// Check if there was a capture by examining the previous FEN.
+	capturedPiece := pieceFromFEN(lastContext.fen, o)
+	if capturedPiece != gochess.Empty {
+		_ = c.board.SetSquare(o, capturedPiece)
+	}
+
+	if c.isCastleMove(move) {
+		_ = c.board.MakeMove(gochess.Coor((o.X+t.X)/2, o.Y), castleRook[move])
+	}
+
+	if c.isEnPassantMove(move) {
+		// Restore the captured pawn.
+		_ = c.board.SetSquare(gochess.Coor(o.X, t.Y), gochess.Pawn|c.turn)
+	}
+}
+
+// movesForPiece returns the available moves for a piece.
+//
+// The function returns a slice of UCI moves.
+// (e.g. "e2e4" for moving the piece at e2 to e4.)
+// Disclaimer: This function does not check if the move is legal for a Chess game.
+func (c Chess) movesForPiece(piece int8, origin gochess.Coordinate) []string {
+	switch piece &^ (gochess.White | gochess.Black) {
+	case gochess.Pawn:
+		return c.pawnMoves(origin)
+	case gochess.Rook:
+		return c.rookMoves(origin)
+	case gochess.Queen:
+		return c.queenMoves(origin)
+	case gochess.King:
+		return append(c.kingMoves(origin), c.kingCastleMoves(origin)...)
+	case gochess.Bishop:
+		return c.bishopMoves(origin)
+	case gochess.Knight:
+		return c.knightMoves(origin)
+	}
+
+	return nil
+}
+
+// pawnMoves returns all the valid pawn moves.
+func (c Chess) pawnMoves(origin gochess.Coordinate) []string {
+	p, _ := c.board.Square(origin)
+	dir := -1
+	if p&gochess.White == gochess.Empty {
+		dir = 1
+	}
+
+	isPromotion := false
+	tCor := gochess.Coor(origin.X, origin.Y+1*dir)
+	if tCor.Y == 7 || tCor.Y == 0 {
+		isPromotion = true
+	}
+
+	moves := make([]string, 0, 2)
+	s, _ := c.board.Square(tCor)
+	if s == gochess.Empty {
+		moves = append(moves, UCI(origin, tCor))
+	}
+
+	if isPromotion {
+		return append(c.pawnCaptureMoves(origin, true), c.promotionPosibilities(origin, tCor)...)
+	}
+
+	if !(dir == 1 && origin.Y == 1) && !(dir == -1 && origin.Y == 6) {
+		return append(c.pawnCaptureMoves(origin, false), moves...)
+	}
+
+	tCor = gochess.Coor(origin.X, origin.Y+2*dir)
+	s, _ = c.board.Square(tCor)
+	if s == gochess.Empty {
+		moves = append(moves, UCI(origin, tCor))
+	}
+
+	return append(c.pawnCaptureMoves(origin, false), moves...)
+}
+
+// pawnCaptureMoves returns all the valid pawn capture moves.
+func (c Chess) pawnCaptureMoves(origin gochess.Coordinate, isPromotion bool) []string {
+	p, _ := c.board.Square(origin)
+	pColor := p & (gochess.White | gochess.Black)
+	dir := -1
+	if pColor == gochess.Black {
+		dir = 1
+	}
+
+	moves := make([]string, 0, 2)
+	offsets := []int{-1, 1}
+	for _, o := range offsets {
+		tCor := gochess.Coor(origin.X+o, origin.Y+1*dir)
+		if tCor.X < 0 || tCor.X > 7 || tCor.Y < 0 || tCor.Y > 7 {
+			continue
+		}
+
+		if CoordinateToAlgebraic(tCor) == c.enPassantSquare {
+			moves = append(moves, UCI(origin, tCor))
+			continue
+		}
+
+		ts, _ := c.board.Square(tCor)
+		if ts == gochess.Empty || ts&pColor != gochess.Empty {
+			continue
+		}
+
+		if !isPromotion {
+			moves = append(moves, UCI(origin, tCor))
+			continue
+		}
+
+		moves = append(moves, c.promotionPosibilities(origin, tCor)...)
+	}
+
+	return moves
+}
+
+// promotionPosibilities is a helper function that returns the UCI moves with
+// the value of the piece to be promoted.
+func (c Chess) promotionPosibilities(origin, target gochess.Coordinate) []string {
+	moves := make([]string, 4)
+	for i, p := range []int8{gochess.Queen, gochess.Rook, gochess.Bishop, gochess.Knight} {
+		moves[i] = UCI(origin, target, p)
+	}
+
+	return moves
+}
+
+// knightMoves returns valid knight moves.
+func (c Chess) knightMoves(origin gochess.Coordinate) []string {
+	offsets := []gochess.Coordinate{
+		{X: 1, Y: 2}, {X: 2, Y: 1},
+		{X: 1, Y: -2}, {X: 2, Y: -1},
+		{X: -1, Y: 2}, {X: -2, Y: 1},
+		{X: -1, Y: -2}, {X: -2, Y: -1},
+	}
+
+	return c.oneStepPieces(origin, offsets)
+}
+
+// kingMoves returns valid king moves.
+func (c Chess) kingMoves(origin gochess.Coordinate) []string {
+	offsets := []gochess.Coordinate{
+		{X: 1, Y: 1}, {X: 1, Y: 0}, {X: 1, Y: -1},
+		{X: 0, Y: 1}, {X: 0, Y: -1},
+		{X: -1, Y: 1}, {X: -1, Y: 0}, {X: -1, Y: -1},
+	}
+
+	return c.oneStepPieces(origin, offsets)
+}
+
+// kingCastleMoves returns valid castle moves.
+func (c Chess) kingCastleMoves(origin gochess.Coordinate) []string {
+	if c.availableCastles == "-" {
+		return nil
+	}
+
+	p, _ := c.board.Square(origin)
+	kingColor := p & (gochess.White | gochess.Black)
+
+	castleDirections := map[string]int{
+		"k": 1, "K": 1,
+		"q": -1, "Q": -1,
+	}
+
+	moves := make([]string, 0, 2)
+	for castle, dir := range castleDirections {
+		if !strings.Contains(c.availableCastles, castle) {
+			continue
+		}
+
+		if gochess.Pieces[castle]&kingColor == gochess.Empty {
+			continue
+		}
+
+		ts, err := c.board.Square(gochess.Coor(origin.X+dir, origin.Y))
+		if err != nil || ts != gochess.Empty {
+			continue
+		}
+
+		ts, err = c.board.Square(gochess.Coor(origin.X+2*dir, origin.Y))
+		if err != nil || ts != gochess.Empty {
+			continue
+		}
+
+		moves = append(moves, UCI(origin, gochess.Coor(origin.X+2*dir, origin.Y)))
+
+		if len(moves) == 2 {
+			break
+		}
+	}
+
+	return moves
+}
+
+// rookMoves returns valid rook moves.
+func (c Chess) rookMoves(origin gochess.Coordinate) []string {
+	offsets := []gochess.Coordinate{{X: 1, Y: 0}, {X: -1, Y: 0}, {X: 0, Y: 1}, {X: 0, Y: -1}}
+	return c.slidingPieces(origin, offsets)
+}
+
+// bishopMoves returns valid bishop moves.
+func (c Chess) bishopMoves(origin gochess.Coordinate) []string {
+	offsets := []gochess.Coordinate{{X: 1, Y: 1}, {X: -1, Y: 1}, {X: 1, Y: -1}, {X: -1, Y: -1}}
+	return c.slidingPieces(origin, offsets)
+}
+
+// queenMoves returns valid queen moves.
+func (c Chess) queenMoves(origin gochess.Coordinate) []string {
+	return append(c.rookMoves(origin), c.bishopMoves(origin)...)
+}
+
+// slidingPieces returns valid moves for sliding pieces.
+func (c Chess) slidingPieces(origin gochess.Coordinate, offsets []gochess.Coordinate) []string {
+	p, _ := c.board.Square(origin)
+
+	color := p & (gochess.White | gochess.Black)
+	moves := make([]string, 0, capacityByPiece[p])
+	for _, d := range offsets {
+		for i := 1; ; i++ {
+			tCor := gochess.Coor(origin.X+i*d.X, origin.Y+i*d.Y)
+			ts, err := c.board.Square(tCor)
+			if err != nil {
+				break
+			}
+
+			if ts == gochess.Empty {
+				moves = append(moves, UCI(origin, tCor))
+				continue
+			}
+
+			if ts&color == gochess.Empty {
+				moves = append(moves, UCI(origin, tCor))
+				break
+			}
+
+			// If the piece is the same color, stop looking in that direction.
+			break
+		}
+	}
+
+	return moves
+}
+
+func (c Chess) oneStepPieces(origin gochess.Coordinate, offsets []gochess.Coordinate) []string {
+	p, _ := c.board.Square(origin)
+
+	color := p & (gochess.White | gochess.Black)
+	moves := make([]string, 0, 8)
+	for _, d := range offsets {
+		tCor := gochess.Coor(origin.X+d.X, origin.Y+d.Y)
+		ts, err := c.board.Square(tCor)
+		if err != nil {
+			continue
+		}
+
+		if ts == gochess.Empty {
+			moves = append(moves, UCI(origin, tCor))
+			continue
+		}
+
+		if ts&color == gochess.Empty {
+			moves = append(moves, UCI(origin, tCor))
+		}
+	}
+
+	return moves
+}
+
+// isCastleMove returns if the move is a castle move.
+//
+// The passed move must be valid.
+func (c Chess) isCastleMove(move string) bool {
+	if castlesMoves[move] != c.turn {
+		return false
+	}
+
+	origin, _ := AlgebraicToCoordinate(move[:2])
+	p, _ := c.board.Square(origin)
+
+	return p == gochess.King|c.turn
+}
+
+// isEnPassantMove returns if the move is an en passant capture move.
+//
+// The passed move must be valid.
+func (c Chess) isEnPassantMove(move string) bool {
+	if c.enPassantSquare == "" {
+		return false
+	}
+
+	origin, _ := AlgebraicToCoordinate(move[:2])
+
+	if move[2:4] != c.enPassantSquare {
+		return false
+	}
+
+	p, _ := c.board.Square(origin)
+	return p&^(gochess.White|gochess.Black) == gochess.Pawn
+}
+
+// destinationMatch looks for a destination in a list of moves.
+// It returns true if any of the moves has the destination.
+// The function expects the moves in UCI format.
+func destinationMatch(moves []string, destination gochess.Coordinate) bool {
+	algCoor := CoordinateToAlgebraic(destination)
+	for _, move := range moves {
+		dest := move[2:4]
+		if dest == algCoor {
+			return true
+		}
+	}
+
+	return false
+}
+
+// legalMoves returns the legal moves for the current turn.
+func (c Chess) legalMoves() []string {
+	moves := c.availableMoves()
+	legalMoves := make([]string, 0, len(moves))
+
+	goroutinesCount := c.config.Parallelism
+	_, ok := c.board.(Cloner)
+	if !ok || goroutinesCount <= 1 {
+		return c.calculateLegalMovesSecuentially(moves)
+	}
+
+	wg := &sync.WaitGroup{}
+	availableMovesChan := make(chan string, goroutinesCount)
+	legalMovesChan := make(chan string, len(moves))
+	wg.Add(goroutinesCount)
+	for range goroutinesCount {
+		go func() {
+			defer wg.Done()
+			copy := c.clone()
+
+			for move := range availableMovesChan {
+				if copy.isLegalMove(move) {
+					legalMovesChan <- move
+				}
+			}
+		}()
+	}
+
+	for _, move := range moves {
+		availableMovesChan <- move
+	}
+
+	close(availableMovesChan)
+	wg.Wait()
+	close(legalMovesChan)
+
+	for move := range legalMovesChan {
+		legalMoves = append(legalMoves, move)
+	}
+
+	// If there are no legal moves, we need to check if position is checkmate or
+	// stalemate.
+	if len(legalMoves) == 0 {
+		if c.isCheck() {
+			legalMoves = nil
+		}
+	}
+
+	return legalMoves
+}
+
+func (c Chess) calculateLegalMovesSecuentially(moves []string) []string {
+	legalMoves := make([]string, 0, len(moves))
+	for _, move := range moves {
+		if c.isLegalMove(move) {
+			legalMoves = append(legalMoves, move)
+		}
+	}
+
+	// If there are no legal moves, we need to check if position is checkmate or
+	// stalemate.
+	if len(legalMoves) == 0 {
+		if c.isCheck() {
+			legalMoves = nil
+		}
+	}
+
+	return legalMoves
+}
+
+// availableMoves returns the available moves for the current turn without checking if they are legal.
+func (c Chess) availableMoves() []string {
+	moves := make([]string, 0, 40)
+	for x := range 8 {
+		for y := range 8 {
+			origin := gochess.Coor(x, y)
+			piece, _ := c.board.Square(origin)
+			if piece&c.turn == gochess.Empty {
+				continue
+			}
+
+			moves = append(moves, c.movesForPiece(piece, origin)...)
+		}
+	}
+
+	return moves
+}
+
+// isLegalMove is a helper function that verifies if the move is legal.
+//
+// It verifies it making the move in a temporary board and checking if the
+// king is in check or the king way is under attack in castling moves.
+func (c Chess) isLegalMove(move string) bool {
+	kingsColor := c.turn
+
+	c.makeMove(move)
+
+	availableMoves := c.availableMoves()
+	kingPosition := c.kingsPosition(kingsColor)
+
+	kingUnderAttack := destinationMatch(availableMoves, kingPosition)
+	c.unmakeMove()
+
+	// If the king is under attack, the move is not legal.
+	if kingUnderAttack {
+		return false
+	}
+
+	// If the move is a castle and the king way is under attack, the move is not legal.
+	if c.isCastleMove(move) && destinationMatch(availableMoves, castleKingWay[move]) {
+		return false
+	}
+
+	return true
+}

--- a/chess/options.go
+++ b/chess/options.go
@@ -2,16 +2,10 @@ package chess
 
 import (
 	"fmt"
-
-	"github.com/RchrdHndrcks/gochess"
 )
 
 // Option is a function that configures a chess.
 type Option func(*Chess) error
-
-const (
-	defaultFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-)
 
 // WithBoard sets the board of the chess.
 // If the board is nil, it returns an error.
@@ -28,11 +22,6 @@ func WithBoard(b Board) Option {
 // If you try to set the FEN before the board, it will set the default board.
 func WithFEN(FEN string) Option {
 	return func(c *Chess) error {
-		if c.board == nil {
-			b, _ := gochess.NewBoard(8)
-			_ = WithBoard(b)(c)
-		}
-
 		if err := c.LoadPosition(FEN); err != nil {
 			return fmt.Errorf("failed to load position: %w", err)
 		}
@@ -41,14 +30,12 @@ func WithFEN(FEN string) Option {
 	}
 }
 
-// defaultOptions check if the setted options are valid and if not, set the default options.
-func defaultOptions(chess *Chess) {
-	if chess.board == nil {
-		b, _ := gochess.NewBoard(8)
-		_ = WithBoard(b)(chess)
-	}
-
-	if chess.FEN() == "" {
-		_ = WithFEN(defaultFEN)(chess)
+// WithParallelism sets the number of workers to use for the moves calculation.
+// If the number of workers is less or equal to 1, the Chess will use the sequential
+// version without throwing goroutines.
+func WithParallelism(n int) Option {
+	return func(c *Chess) error {
+		c.config.Parallelism = n
+		return nil
 	}
 }

--- a/chess/options_test.go
+++ b/chess/options_test.go
@@ -1,0 +1,34 @@
+package chess
+
+import (
+	"testing"
+
+	"github.com/RchrdHndrcks/gochess"
+)
+
+func TestWithParallelism(t *testing.T) {
+	c, err := New(WithParallelism(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.config.Parallelism != 2 {
+		t.Errorf("expected parallelism to be 2, got %d", c.config.Parallelism)
+	}
+}
+
+func TestWithBoard(t *testing.T) {
+	board, err := gochess.NewBoard(8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := New(WithBoard(board))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.board.Width() != 8 {
+		t.Errorf("expected board width to be 8, got %d", c.board.Width())
+	}
+}


### PR DESCRIPTION
## Copilot Description

This pull request introduces several updates to the chess library, including enhancements to the board functionality, test coverage, and benchmarking, as well as cleanup of unused configuration and code. The most significant changes include the addition of a default chessboard initializer, a deep cloning method for boards, new benchmarks for move sequences, and the removal of unnecessary configurations and default options.

### Board Enhancements:
* Added `DefaultChessBoard` method in `board.go` to initialize a standard chessboard with default piece positions.
* Introduced a `Clone` method in `board.go` to create a deep copy of a board, ensuring modifications to one instance do not affect another.

### Testing Improvements:
* Added a `TestClone` test in `board_test.go` to verify the functionality of the new `Clone` method.
* Simplified and extended test cases in `chess_test.go`, including the removal of redundant manual board setup and the addition of a comprehensive test for the Capablanca-Steiner game. [[1]](diffhunk://#diff-30c4629863d09ca34dc8495ed76e6fa63e300a51eef904972f1092976ae3d102L295-L302) [[2]](diffhunk://#diff-30c4629863d09ca34dc8495ed76e6fa63e300a51eef904972f1092976ae3d102L568-L681)

### Benchmarking:
* Added new benchmarks in `chess_benchmark_test.go` to measure performance for specific move sequences, such as the Capablanca-Steiner game and various other moves.

### Code Cleanup:
* Removed unused `errcheck` linter settings from `.golangci.yml`.
* Deleted default FEN setup and redundant default option logic from `chess/options.go`, streamlining the initialization process. [[1]](diffhunk://#diff-76f759b27cb910e7f17a07456f48f1f79dd7688f767ff84b8ae82f75fbbe3081L5-L15) [[2]](diffhunk://#diff-76f759b27cb910e7f17a07456f48f1f79dd7688f767ff84b8ae82f75fbbe3081L31-L54)

### Adapter Addition:
* Introduced a `boardAdapter` in `chess/adapter.go` to wrap the `Board` and provide a `Clone` method, facilitating integration with the chess library.


## Analyzed
After a few changes in the way the moves are calculated (from sequential to parallel), the benchmark shows amazing improvements:

In my machine, these are the results before the changes:
> BenchmarkCapablancaSteiner-8    21    53296026 ns/op    22903392 B/op    998038 allocs/op
> BenchmarkVariousMoves-8         21    52990313 ns/op    22837260 B/op    998023 allocs/op

These are the results now:
> BenchmarkCapablancaSteiner-8    70    16576849 ns/op    21454491 B/op    480480 allocs/op
> BenchmarkVariousMoves-8         72    16567114 ns/op    21470962 B/op    480477 allocs/op

This implies better performance in execution time (~69% better), memory usage (~6% better) and memory allocation (~52% better)