### PR TITLE
Adjust chess.New comment

### DIFF
--- a/chess/chess.go
+++ b/chess/chess.go
@@ -118,15 +118,15 @@ var (
 
 // New creates a new chess game.
 //
-// The function will up a pool of workers to maximize performance on the
-// moves calculation.
+// The chess.AvailableMoves method will use a pool of workers to maximize
+// performance on the moves calculation.
 // By default, the number of workers is twice the number of available CPUs.
 // If you are running on a container environment or you want to use the
 // sequential version, you should set this value manually using the
 // WithParallelism option.
 // The pool of workers will be used only if the board implements the Cloner
-// interface. If you are using a custom Board implementation, you should
-// implement the Cloner interface to take advantage of the parallelism.
+// interface. If you are using a custom Board with the WithBoard option, you
+// should implement the Cloner interface to take advantage of the parallelism.
 func New(opts ...Option) (*Chess, error) {
 	c := &Chess{
 		board:            newBoardAdapter(gochess.DefaultChessBoard()),


### PR DESCRIPTION
This pull request updates the documentation for the `New` function in `chess/chess.go` to clarify the behavior of the `chess.AvailableMoves` method and its use of parallelism.

Documentation updates:

* Clarified that the `chess.AvailableMoves` method uses a pool of workers to maximize performance for move calculations, and specified that this applies when the `Cloner` interface is implemented.
* Updated references to custom board implementations to explicitly mention the `WithBoard` option when using a custom `Board`.