### PR TITLE
Add v1.2.0 tag to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-05-09
+
 ### Changed
 
 - [#19](https://github.com/RchrdHndrcks/gochess/pull/19) Improve API for Chess and Board.


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` file to document the release of version 1.2.0, including a notable improvement to the API for Chess and Board.

Release updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R11): Added a new section for version 1.2.0, dated 2025-05-09, and included a change entry for improving the API for Chess and Board.