### PR TITLE
Fix: propagate board error in Chess.Square()

### DIFF
--- a/chess/chess.go
+++ b/chess/chess.go
@@ -258,7 +258,7 @@ func (c *Chess) Square(square string) (string, error) {
 
 	p, err := c.board.Square(coor)
 	if err != nil {
-		return "", fmt.Errorf("failed to get piece from board: %w", err)
+		return "", fmt.Errorf("failed to get piece from board at %s: %w", square, err)
 	}
 
 	return gochess.PieceNames[p], nil

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -256,9 +256,11 @@ func (c *Chess) Square(square string) (string, error) {
 		return "", fmt.Errorf("failed to convert algebraic notation to coordinate: %w", err)
 	}
 
-	// Ignore the error because the coordinates is
-	// already validated.
-	p, _ := c.board.Square(coor)
+	p, err := c.board.Square(coor)
+	if err != nil {
+		return "", fmt.Errorf("failed to get piece from board: %w", err)
+	}
+
 	return gochess.PieceNames[p], nil
 }
 

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -1,6 +1,7 @@
 package chess_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/RchrdHndrcks/gochess"
@@ -543,7 +544,32 @@ func TestSquare(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Equal(t, "failed to convert algebraic notation to coordinate: coordinate out of bounds", err.Error())
 	})
+
+	t.Run("Board error is propagated", func(t *testing.T) {
+		// Arrange
+		boardErr := errors.New("custom board failure")
+		c, errOpts := chess.New(chess.WithBoard(&errorBoard{squareErr: boardErr}))
+		require.Nil(t, errOpts)
+
+		// Act
+		piece, err := c.Square("e2")
+
+		// Assert
+		require.NotNil(t, err)
+		assert.Empty(t, piece)
+		assert.ErrorIs(t, err, boardErr)
+		assert.Contains(t, err.Error(), "e2")
+	})
 }
+
+// errorBoard is a mock Board implementation that returns an error on Square().
+type errorBoard struct {
+	squareErr error
+}
+
+func (b *errorBoard) SetSquare(_ gochess.Coordinate, _ int8) error { return nil }
+func (b *errorBoard) Square(_ gochess.Coordinate) (int8, error)    { return 0, b.squareErr }
+func (b *errorBoard) Width() int                                   { return 8 }
 
 func TestMakeMove_ScholarMate(t *testing.T) {
 	// Arrange


### PR DESCRIPTION
## Summary
- The `Square()` method in `chess/chess.go` was silently discarding the error returned by `c.board.Square(coor)` using `p, _ := c.board.Square(coor)`.
- This change propagates the error properly, returning it to the caller wrapped with context.
- While the coordinate is validated before the call, ignoring errors from the board layer could hide bugs in custom `Board` implementations.

## Test plan
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)