### PR TITLE
Fix panic when history is empty in updateHalfMoves

### DIFF
--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -269,6 +269,10 @@ func (c *Chess) updateCastlePossibilities() {
 // It must be called after a move is made. If no move was made,
 // the function will panic.
 func (c *Chess) updateHalfMoves() {
+	if len(c.history) == 0 {
+		return
+	}
+
 	c.halfMoves++
 	h := c.history[len(c.history)-1]
 


### PR DESCRIPTION
## Summary
- Add a guard check in `updateHalfMoves()` to return early when `c.history` is empty, preventing an index out of range panic on `c.history[len(c.history)-1]`
- The half-move counter retains its current value when history is empty, which is the correct default behavior

## Test plan
- [x] Existing tests pass (`go test ./...`)
- [ ] Verify no regression in FEN calculation after moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)