### PR TITLE
Fix benchmark nil check for AvailableMoves

### DIFF
--- a/chess/chess_benchmark_test.go
+++ b/chess/chess_benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkCapablancaSteiner(b *testing.B) {
 			b.Fatalf("Unexpected final position: %s", c.FEN())
 		}
 
-		if c.AvailableMoves() != nil {
+		if len(c.AvailableMoves()) != 0 {
 			b.Fatalf("Expected no legal moves, but got some")
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix logic error in `BenchmarkCapablancaSteiner` where `AvailableMoves() != nil` was used to check for no legal moves
- `AvailableMoves()` returns an empty `[]string{}` (non-nil) when there are no moves, so the nil check never catches failures
- Changed to `len(c.AvailableMoves()) != 0` which correctly detects when moves are unexpectedly present

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)