### PR TITLE
Add Piece type for compile-time type safety

### DIFF
--- a/board.go
+++ b/board.go
@@ -6,14 +6,14 @@ import (
 
 // Board is a 2D array of pieces.
 type Board struct {
-	squares [][]int8
+	squares [][]Piece
 	width   int
 }
 
 // DefaultChessBoard returns the default chess board.
 func DefaultChessBoard() *Board {
 	return &Board{
-		squares: [][]int8{
+		squares: [][]Piece{
 			{Black | Rook, Black | Knight, Black | Bishop, Black | Queen, Black | King, Black | Bishop, Black | Knight, Black | Rook},
 			{Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn, Black | Pawn},
 			{Empty, Empty, Empty, Empty, Empty, Empty, Empty, Empty},
@@ -37,7 +37,7 @@ func DefaultChessBoard() *Board {
 // - The width of the squares is different from the width of the board.
 // - The length of the squares array is different from the width of the board.
 // - The length of the inner arrays is different from the width of the board.
-func NewBoard(width int, squares ...[]int8) (*Board, error) {
+func NewBoard(width int, squares ...[]Piece) (*Board, error) {
 	if width < 1 {
 		return nil, fmt.Errorf("board: %w: %d", ErrInvalidWidth, width)
 	}
@@ -61,9 +61,9 @@ func NewBoard(width int, squares ...[]int8) (*Board, error) {
 		}, nil
 	}
 
-	s := make([][]int8, width)
+	s := make([][]Piece, width)
 	for i := range width {
-		s[i] = make([]int8, width)
+		s[i] = make([]Piece, width)
 	}
 
 	return &Board{
@@ -80,7 +80,7 @@ func (b *Board) Width() int {
 // Square returns the piece at the given Coordinate.
 //
 // It returns ErrInvalidCoordinate if the Coordinate is out of bounds.
-func (b *Board) Square(c Coordinate) (int8, error) {
+func (b *Board) Square(c Coordinate) (Piece, error) {
 	if !b.isValidCoordinate(c) {
 		return Empty, fmt.Errorf("board: %w: %v", ErrInvalidCoordinate, c)
 	}
@@ -91,7 +91,7 @@ func (b *Board) Square(c Coordinate) (int8, error) {
 // SetSquare sets a piece in a square.
 //
 // It will return ErrInvalidCoordinate if the coordinate is out of bounds.
-func (b *Board) SetSquare(c Coordinate, p int8) error {
+func (b *Board) SetSquare(c Coordinate, p Piece) error {
 	if !b.isValidCoordinate(c) {
 		return fmt.Errorf("board: %w: %v", ErrInvalidCoordinate, c)
 	}
@@ -103,9 +103,9 @@ func (b *Board) SetSquare(c Coordinate, p int8) error {
 // Clone returns a copy of the board.
 func (b *Board) Clone() *Board {
 	var cloned Board
-	cloned.squares = make([][]int8, b.width)
+	cloned.squares = make([][]Piece, b.width)
 	for i := range b.width {
-		cloned.squares[i] = make([]int8, b.width)
+		cloned.squares[i] = make([]Piece, b.width)
 		copy(cloned.squares[i], b.squares[i])
 	}
 	cloned.width = b.width

--- a/board_test.go
+++ b/board_test.go
@@ -32,7 +32,7 @@ func TestNewBoard(t *testing.T) {
 
 	t.Run("With Valid Squares", func(t *testing.T) {
 		// Arrange
-		squares := [][]int8{
+		squares := [][]gochess.Piece{
 			{gochess.Empty, gochess.Empty, gochess.Empty},
 			{gochess.Empty, gochess.White | gochess.King, gochess.Empty},
 			{gochess.Empty, gochess.Empty, gochess.Black | gochess.Queen},
@@ -58,7 +58,7 @@ func TestNewBoard(t *testing.T) {
 
 	t.Run("With Invalid Squares Length", func(t *testing.T) {
 		// Arrange
-		squares := [][]int8{
+		squares := [][]gochess.Piece{
 			{gochess.Empty, gochess.Empty},
 			{gochess.Empty, gochess.White | gochess.King},
 		}
@@ -74,7 +74,7 @@ func TestNewBoard(t *testing.T) {
 
 	t.Run("With Invalid Row Length", func(t *testing.T) {
 		// Arrange
-		squares := [][]int8{
+		squares := [][]gochess.Piece{
 			{gochess.Empty, gochess.Empty, gochess.Empty},
 			{gochess.Empty, gochess.White | gochess.King},
 			{gochess.Empty, gochess.Empty, gochess.Black | gochess.Queen},
@@ -124,7 +124,7 @@ func TestWidth(t *testing.T) {
 func TestSquare(t *testing.T) {
 	t.Run("Valid Coordinates", func(t *testing.T) {
 		// Arrange
-		squares := [][]int8{
+		squares := [][]gochess.Piece{
 			{gochess.White | gochess.Rook, gochess.White | gochess.Knight, gochess.White | gochess.Bishop},
 			{gochess.White | gochess.Pawn, gochess.Empty, gochess.Empty},
 			{gochess.Empty, gochess.Black | gochess.Pawn, gochess.Empty},
@@ -136,7 +136,7 @@ func TestSquare(t *testing.T) {
 		// Test cases
 		testCases := []struct {
 			coord    gochess.Coordinate
-			expected int8
+			expected gochess.Piece
 		}{
 			{gochess.Coor(0, 0), gochess.White | gochess.Rook},
 			{gochess.Coor(1, 0), gochess.White | gochess.Knight},
@@ -216,7 +216,7 @@ func TestSetSquare(t *testing.T) {
 		// Test cases
 		testCases := []struct {
 			coord gochess.Coordinate
-			piece int8
+			piece gochess.Piece
 		}{
 			{gochess.Coor(0, 0), gochess.White | gochess.Rook},
 			{gochess.Coor(1, 0), gochess.White | gochess.Knight},

--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -35,9 +35,9 @@ func (c *Chess) loadPosition(FEN string) error {
 	var whiteKing, blackKing int
 	var whiteKingPosition, blackKingPosition *gochess.Coordinate
 
-	brd := make([][]int8, 8)
+	brd := make([][]gochess.Piece, 8)
 	for y := range 8 {
-		row := make([]int8, 8)
+		row := make([]gochess.Piece, 8)
 
 		if len(fenRows[y]) == 0 || len(fenRows[y]) > 8 {
 			return fmt.Errorf("invalid FEN: %s", FEN)
@@ -412,7 +412,7 @@ func (c Chess) isCheck() bool {
 }
 
 // kingsPosition returns the position of the king of the given color.
-func (c Chess) kingsPosition(color int8) gochess.Coordinate {
+func (c Chess) kingsPosition(color gochess.Piece) gochess.Coordinate {
 	if color == gochess.White {
 		return *c.whiteKingPosition
 	}
@@ -425,7 +425,7 @@ func (c Chess) kingsPosition(color int8) gochess.Coordinate {
 //
 // It must be called with a valid coordinate and a valid FEN string.
 // If there is no piece at the given coordinate, it returns gochess.Empty.
-func pieceFromFEN(fen string, coord gochess.Coordinate) int8 {
+func pieceFromFEN(fen string, coord gochess.Coordinate) gochess.Piece {
 	fenRow := strings.Split(strings.Split(fen, " ")[0], "/")[coord.Y]
 	var count int
 	for _, c := range fenRow {

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -18,9 +18,9 @@ type (
 	// Board represents a chess board.
 	Board interface {
 		// SetSquare sets a piece in a square.
-		SetSquare(c gochess.Coordinate, p int8) error
+		SetSquare(c gochess.Coordinate, p gochess.Piece) error
 		// Square returns the piece in a square.
-		Square(c gochess.Coordinate) (int8, error)
+		Square(c gochess.Coordinate) (gochess.Piece, error)
 		// Width returns the width of the board.
 		Width() int
 	}
@@ -59,7 +59,7 @@ type (
 	Chess struct {
 		board Board
 		// turn is the current turn.
-		turn int8
+		turn gochess.Piece
 		// movesCount is the number of moves played in algebaric notation.
 		// It will increase by 1 after each black move.
 		movesCount uint64
@@ -94,7 +94,7 @@ type (
 )
 
 var (
-	castlesMoves = map[string]int8{
+	castlesMoves = map[string]gochess.Piece{
 		"e1g1": gochess.White,
 		"e1c1": gochess.White,
 		"e8g8": gochess.Black,
@@ -186,7 +186,7 @@ func (c *Chess) LoadPosition(FEN string) error {
 // Turn returns the current turn.
 //
 // It will be gochess.White or gochess.Black.
-func (c *Chess) Turn() int8 {
+func (c *Chess) Turn() gochess.Piece {
 	return c.turn
 }
 

--- a/chess/move.go
+++ b/chess/move.go
@@ -41,7 +41,7 @@ func CoordinateToAlgebraic(c gochess.Coordinate) string {
 //
 // If the move is a promotion, it receives the piece to promote to. If it receives more
 // than one piece, it returns the first one.
-func UCI(origin, target gochess.Coordinate, piece ...int8) string {
+func UCI(origin, target gochess.Coordinate, piece ...gochess.Piece) string {
 	p := ""
 	if len(piece) > 0 {
 		pi := piece[0]

--- a/chess/move_test.go
+++ b/chess/move_test.go
@@ -13,7 +13,7 @@ func TestUCI(t *testing.T) {
 	t.Run("a1 to a2", func(t *testing.T) {
 		oCor := gochess.Coor(0, 7)
 		tCor := gochess.Coor(0, 6)
-		var promotionPiece int8
+		var promotionPiece gochess.Piece
 		expected := "a1a2"
 
 		got := chess.UCI(oCor, tCor, promotionPiece)
@@ -24,7 +24,7 @@ func TestUCI(t *testing.T) {
 	t.Run("a1 to b2", func(t *testing.T) {
 		oCor := gochess.Coor(0, 7)
 		tCor := gochess.Coor(1, 6)
-		var promotionPiece int8
+		var promotionPiece gochess.Piece
 		expected := "a1b2"
 
 		got := chess.UCI(oCor, tCor, promotionPiece)
@@ -35,7 +35,7 @@ func TestUCI(t *testing.T) {
 	t.Run("a1 to b1", func(t *testing.T) {
 		oCor := gochess.Coor(0, 7)
 		tCor := gochess.Coor(1, 7)
-		var promotionPiece int8
+		var promotionPiece gochess.Piece
 		expected := "a1b1"
 
 		got := chess.UCI(oCor, tCor, promotionPiece)
@@ -46,7 +46,7 @@ func TestUCI(t *testing.T) {
 	t.Run("a1 to b3", func(t *testing.T) {
 		oCor := gochess.Coor(0, 7)
 		tCor := gochess.Coor(1, 5)
-		var promotionPiece int8
+		var promotionPiece gochess.Piece
 		expected := "a1b3"
 
 		got := chess.UCI(oCor, tCor, promotionPiece)
@@ -57,7 +57,7 @@ func TestUCI(t *testing.T) {
 	t.Run("a1 to h8", func(t *testing.T) {
 		oCor := gochess.Coor(0, 7)
 		tCor := gochess.Coor(7, 0)
-		var promotionPiece int8
+		var promotionPiece gochess.Piece
 		expected := "a1h8"
 
 		got := chess.UCI(oCor, tCor, promotionPiece)

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -10,7 +10,7 @@ import (
 // capacityByPiece is a helper map where the key is the piece and the value is
 // the max moves count for that piece. It is useful to know which capacity asign
 // to the slice where the moves of these pieces are stored.
-var capacityByPiece = map[int8]int{
+var capacityByPiece = map[gochess.Piece]int{
 	gochess.White | gochess.Queen:  27,
 	gochess.Black | gochess.Queen:  27,
 	gochess.White | gochess.Rook:   14,
@@ -160,7 +160,7 @@ func (c *Chess) unmakeMove() {
 // The function returns a slice of UCI moves.
 // (e.g. "e2e4" for moving the piece at e2 to e4.)
 // Disclaimer: This function does not check if the move is legal for a Chess game.
-func (c Chess) movesForPiece(piece int8, origin gochess.Coordinate) []string {
+func (c Chess) movesForPiece(piece gochess.Piece, origin gochess.Coordinate) []string {
 	switch piece &^ (gochess.White | gochess.Black) {
 	case gochess.Pawn:
 		return c.pawnMoves(origin)
@@ -258,7 +258,7 @@ func (c Chess) pawnCaptureMoves(origin gochess.Coordinate, isPromotion bool) []s
 // the value of the piece to be promoted.
 func (c Chess) promotionPosibilities(origin, target gochess.Coordinate) []string {
 	moves := make([]string, 4)
-	for i, p := range []int8{gochess.Queen, gochess.Rook, gochess.Bishop, gochess.Knight} {
+	for i, p := range []gochess.Piece{gochess.Queen, gochess.Rook, gochess.Bishop, gochess.Knight} {
 		moves[i] = UCI(origin, target, p)
 	}
 

--- a/pieces.go
+++ b/pieces.go
@@ -1,42 +1,45 @@
 package gochess
 
+// Piece represents a chess piece with its color encoded as a bitfield.
+type Piece int8
+
 const (
 	// White is the integer value of the white color.
-	White int8 = 0b01000
+	White Piece = 0b01000
 	// Black is the integer value of the black color.
-	Black int8 = 0b10000
+	Black Piece = 0b10000
 
 	// Empty is the integer value of an empty square.
-	Empty int8 = 0b00000
+	Empty Piece = 0b00000
 	// Pawn is the integer value of a pawn piece.
-	Pawn int8 = 0b00001
+	Pawn Piece = 0b00001
 	// Knight is the integer value of a knight piece.
-	Knight int8 = 0b00010
+	Knight Piece = 0b00010
 	// Bishop is the integer value of a bishop piece.
-	Bishop int8 = 0b00011
+	Bishop Piece = 0b00011
 	// Rook is the integer value of a rook piece.
-	Rook int8 = 0b00100
+	Rook Piece = 0b00100
 	// Queen is the integer value of a queen piece.
-	Queen int8 = 0b00101
+	Queen Piece = 0b00101
 	// King is the integer value of a king piece.
-	King int8 = 0b00110
+	King Piece = 0b00110
 )
 
 var (
 	// Colors is a map of color names to their integer values.
-	Colors = map[string]int8{
+	Colors = map[string]Piece{
 		"w": White,
 		"b": Black,
 	}
 
 	// ColorNames is a map of color integer values to their names.
-	ColorNames = map[int8]string{
+	ColorNames = map[Piece]string{
 		White: "w",
 		Black: "b",
 	}
 
 	// PiecesWithoutColor is a map of piece names to their integer values without color.
-	PiecesWithoutColor = map[string]int8{
+	PiecesWithoutColor = map[string]Piece{
 		"p": Pawn, "P": Pawn,
 		"n": Knight, "N": Knight,
 		"b": Bishop, "B": Bishop,
@@ -46,7 +49,7 @@ var (
 	}
 
 	// Pieces is a map of piece names to their integer values.
-	Pieces = map[string]int8{
+	Pieces = map[string]Piece{
 		"p": Black | Pawn, "P": White | Pawn,
 		"n": Black | Knight, "N": White | Knight,
 		"b": Black | Bishop, "B": White | Bishop,
@@ -56,7 +59,7 @@ var (
 	}
 
 	// PieceNames is a map of piece integer values to their names.
-	PieceNames = map[int8]string{
+	PieceNames = map[Piece]string{
 		Black | Pawn: "p", White | Pawn: "P",
 		Black | Knight: "n", White | Knight: "N",
 		Black | Bishop: "b", White | Bishop: "B",


### PR DESCRIPTION
## Summary
- Introduces a `Piece` custom type (`type Piece int8`) to replace raw `int8` constants for chess pieces and colors, providing compile-time type safety.
- Updates all piece/color constants (`White`, `Black`, `Empty`, `Pawn`, `Knight`, `Bishop`, `Rook`, `Queen`, `King`) to use the new `Piece` type.
- Updates the `Board` struct (`squares`, `Square()`, `SetSquare()`, `NewBoard()`, `Clone()`) and the chess package (`Board` interface, `Chess.turn` field, `castlesMoves` map, `Turn()` method, `UCI()`, `movesForPiece()`, `kingsPosition()`, `pieceFromFEN()`, and all map types) to use `gochess.Piece` instead of `int8`.
- Updates all test files to use the new type where applicable.

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests)
- [x] `go fmt ./...` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)