### PR TITLE
Validate map lookups in FEN parsing

### DIFF
--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -50,7 +50,10 @@ func (c *Chess) loadPosition(FEN string) error {
 			n, err := strconv.Atoi(char)
 			// If c is not a number, it's a piece.
 			if err != nil {
-				p := gochess.Pieces[char]
+				p, ok := gochess.Pieces[char]
+				if !ok {
+					return fmt.Errorf("invalid FEN: unknown piece character: %s", char)
+				}
 				row[x] = p
 				coor := gochess.Coor(x, y)
 				if p == gochess.King|gochess.White {
@@ -440,7 +443,10 @@ func pieceFromFEN(fen string, coord gochess.Coordinate) int8 {
 		}
 
 		if count == coord.X {
-			return gochess.Pieces[string(c)]
+			if p, ok := gochess.Pieces[string(c)]; ok {
+				return p
+			}
+			return gochess.Empty
 		}
 
 		count++


### PR DESCRIPTION
## Summary
- Add validation for `gochess.Pieces` map lookups in `chess/FEN.go` using the comma-ok idiom to prevent silent zero-value returns
- In `loadPosition`, an invalid piece character now returns a descriptive error instead of silently inserting a zero value
- In `pieceFromFEN`, an unrecognized character now explicitly returns `gochess.Empty` instead of relying on the map's zero value

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Verify that loading a FEN with an invalid piece character (e.g., `x`) returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)