### PR TITLE
Document that Chess is not safe for concurrent use

### DIFF
--- a/chess/chess.go
+++ b/chess/chess.go
@@ -56,6 +56,8 @@ type (
 	}
 
 	// Chess represents a Chess game.
+	//
+	// A Chess value is not safe for concurrent use by multiple goroutines.
 	Chess struct {
 		board Board
 		// turn is the current turn.


### PR DESCRIPTION
## Summary
- Add a doc comment to the `Chess` struct noting that it is not safe for concurrent use by multiple goroutines, following the standard Go convention for documenting thread-safety.

## Test plan
- [x] `go test ./...` passes with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)