### PR TITLE
Add fifty-move rule detection

### DIFF
--- a/chess/README.md
+++ b/chess/README.md
@@ -37,6 +37,7 @@ func (c *Chess) UnmakeMove()
 func (c *Chess) IsCheck() bool
 func (c *Chess) IsCheckmate() bool
 func (c *Chess) IsStalemate() bool
+func (c *Chess) IsFiftyMoveRule() bool
 func (c *Chess) LoadPosition(fen string) error
 func (c *Chess) Clone() *Chess
 ```
@@ -60,6 +61,8 @@ func (c *Chess) Clone() *Chess
 - `IsCheckmate() bool`: Returns whether the current player's king is in checkmate.
 
 - `IsStalemate() bool`: Returns whether the game is in stalemate.
+
+- `IsFiftyMoveRule() bool`: Returns whether the fifty-move rule draw condition is met (i.e., 50 or more moves have been made by each side without a pawn move or capture).
 
 - `LoadPosition(fen string) error`: Sets up the board according to the provided FEN string.
 

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -248,6 +248,15 @@ func (c *Chess) IsStalemate() bool {
 	return c.stalemate
 }
 
+// IsFiftyMoveRule returns true if the fifty-move rule draw condition is met.
+//
+// The fifty-move rule states that a player can claim a draw if no capture
+// has been made and no pawn has been moved in the last fifty moves
+// (100 half-moves).
+func (c *Chess) IsFiftyMoveRule() bool {
+	return c.halfMoves >= 100
+}
+
 // Square returns the piece in a square.
 // The square is represented by an algebraic notation.
 //

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -841,6 +841,47 @@ func TestLoadPosition_Errors(t *testing.T) {
 	})
 }
 
+func TestIsFiftyMoveRule(t *testing.T) {
+	t.Run("Default position is not fifty-move rule", func(t *testing.T) {
+		// Arrange
+		c, err := chess.New()
+		require.Nil(t, err)
+
+		// Assert
+		assert.False(t, c.IsFiftyMoveRule())
+	})
+
+	t.Run("Position with 99 half-moves becomes fifty-move rule after non-pawn non-capture move", func(t *testing.T) {
+		// Arrange
+		// FEN with halfmoves=99: two kings and two rooks, white to move
+		c, err := chess.New(chess.WithFEN("k7/8/8/8/8/8/8/K6R w - - 99 50"))
+		require.Nil(t, err)
+		assert.False(t, c.IsFiftyMoveRule())
+
+		// Act - make a non-pawn, non-capture move (rook move)
+		err = c.MakeMove("h1g1")
+		require.Nil(t, err)
+
+		// Assert - halfMoves should now be 100
+		assert.True(t, c.IsFiftyMoveRule())
+	})
+
+	t.Run("Pawn move resets counter", func(t *testing.T) {
+		// Arrange
+		// FEN with halfmoves=99: king and pawn, white to move
+		c, err := chess.New(chess.WithFEN("k7/8/8/8/8/8/P7/K7 w - - 99 50"))
+		require.Nil(t, err)
+		assert.False(t, c.IsFiftyMoveRule())
+
+		// Act - make a pawn move
+		err = c.MakeMove("a2a3")
+		require.Nil(t, err)
+
+		// Assert - counter should be reset, not fifty-move rule
+		assert.False(t, c.IsFiftyMoveRule())
+	})
+}
+
 func TestUnmakeMove(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		// Arrange

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -853,7 +853,7 @@ func TestIsFiftyMoveRule(t *testing.T) {
 
 	t.Run("Position with 99 half-moves becomes fifty-move rule after non-pawn non-capture move", func(t *testing.T) {
 		// Arrange
-		// FEN with halfmoves=99: two kings and two rooks, white to move
+		// FEN with halfmoves=99: two kings and a rook, white to move
 		c, err := chess.New(chess.WithFEN("k7/8/8/8/8/8/8/K6R w - - 99 50"))
 		require.Nil(t, err)
 		assert.False(t, c.IsFiftyMoveRule())

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -567,9 +567,9 @@ type errorBoard struct {
 	squareErr error
 }
 
-func (b *errorBoard) SetSquare(_ gochess.Coordinate, _ int8) error { return nil }
-func (b *errorBoard) Square(_ gochess.Coordinate) (int8, error)    { return 0, b.squareErr }
-func (b *errorBoard) Width() int                                   { return 8 }
+func (b *errorBoard) SetSquare(_ gochess.Coordinate, _ gochess.Piece) error { return nil }
+func (b *errorBoard) Square(_ gochess.Coordinate) (gochess.Piece, error)    { return 0, b.squareErr }
+func (b *errorBoard) Width() int                                             { return 8 }
 
 func TestMakeMove_ScholarMate(t *testing.T) {
 	// Arrange


### PR DESCRIPTION
## Summary
- Add `IsFiftyMoveRule() bool` method to `Chess` that returns `true` when `halfMoves >= 100` (100 half-moves = 50 full moves without a pawn move or capture)
- Add tests covering: default position (false), reaching the threshold via a non-pawn non-capture move, and verifying a pawn move resets the counter

## Test plan
- [x] `go test ./...` passes
- [x] Default position returns `false`
- [x] FEN with halfmoves=99 + king/rook move triggers `true`
- [x] FEN with halfmoves=99 + pawn move resets counter, returns `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)