### PR TITLE
Add insufficient material draw detection

### DIFF
--- a/chess/README.md
+++ b/chess/README.md
@@ -38,6 +38,7 @@ func (c *Chess) IsCheck() bool
 func (c *Chess) IsCheckmate() bool
 func (c *Chess) IsStalemate() bool
 func (c *Chess) IsFiftyMoveRule() bool
+func (c *Chess) IsInsufficientMaterial() bool
 func (c *Chess) LoadPosition(fen string) error
 func (c *Chess) Clone() *Chess
 ```
@@ -63,6 +64,8 @@ func (c *Chess) Clone() *Chess
 - `IsStalemate() bool`: Returns whether the game is in stalemate.
 
 - `IsFiftyMoveRule() bool`: Returns whether the fifty-move rule draw condition is met (i.e., 50 or more moves have been made by each side without a pawn move or capture).
+
+- `IsInsufficientMaterial() bool`: Returns whether neither side has sufficient material to deliver checkmate (K vs K, K+N vs K, K+B vs K, K+B vs K+B same color squares). Based on FIDE Laws of Chess article 5.2.2.
 
 - `LoadPosition(fen string) error`: Sets up the board according to the provided FEN string.
 

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -258,12 +258,21 @@ func (c *Chess) IsFiftyMoveRule() bool {
 }
 
 // IsInsufficientMaterial returns true if neither side has sufficient material
-// to checkmate the opponent. The following positions are considered
-// insufficient material:
-//   - King vs King
-//   - King + Knight vs King
-//   - King + Bishop vs King
-//   - King + Bishop vs King + Bishop (bishops on same color squares)
+// to checkmate the opponent, as defined by FIDE Laws of Chess article 5.2.2.
+//
+// The following positions are considered insufficient material:
+//   - King vs King: bare kings cannot deliver checkmate by any legal sequence.
+//   - King + Knight vs King: a lone knight cannot force checkmate without the
+//     opponent's cooperation.
+//   - King + Bishop vs King: a bishop controls only one square color, so the
+//     defending king can always evade.
+//   - King + Bishop vs King + Bishop (same color squares): the attacking bishop
+//     can never reach the squares the defending bishop occupies, so no forced
+//     mate exists. Opposite-color bishops are NOT insufficient — they can
+//     cooperate to deliver checkmate.
+//
+// Any other material (pawn, rook, queen, two or more knights, or mixed minor
+// pieces not listed above) is considered sufficient.
 func (c *Chess) IsInsufficientMaterial() bool {
 	width := c.board.Width()
 
@@ -279,7 +288,7 @@ func (c *Chess) IsInsufficientMaterial() bool {
 				continue
 			}
 
-			pieceType := piece & 0b00111
+			pieceType := piece &^ (gochess.White | gochess.Black)
 			switch pieceType {
 			case gochess.King:
 				// Kings are always present, skip them.

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -257,6 +257,70 @@ func (c *Chess) IsFiftyMoveRule() bool {
 	return c.halfMoves >= 100
 }
 
+// IsInsufficientMaterial returns true if neither side has sufficient material
+// to checkmate the opponent. The following positions are considered
+// insufficient material:
+//   - King vs King
+//   - King + Knight vs King
+//   - King + Bishop vs King
+//   - King + Bishop vs King + Bishop (bishops on same color squares)
+func (c *Chess) IsInsufficientMaterial() bool {
+	width := c.board.Width()
+
+	var knights, bishops int
+	var bishopSquareColor int // stores (x+y)%2 of the first bishop found
+	bishopSquareColor = -1
+	allBishopsSameColor := true
+
+	for y := range width {
+		for x := range width {
+			piece, _ := c.board.Square(gochess.Coor(x, y))
+			if piece == gochess.Empty {
+				continue
+			}
+
+			pieceType := piece & 0b00111
+			switch pieceType {
+			case gochess.King:
+				// Kings are always present, skip them.
+				continue
+			case gochess.Knight:
+				knights++
+			case gochess.Bishop:
+				bishops++
+				sc := (x + y) % 2
+				if bishopSquareColor == -1 {
+					bishopSquareColor = sc
+				} else if sc != bishopSquareColor {
+					allBishopsSameColor = false
+				}
+			default:
+				// Any other piece (pawn, rook, queen) means sufficient material.
+				return false
+			}
+		}
+	}
+
+	totalMinor := knights + bishops
+
+	// King vs King
+	if totalMinor == 0 {
+		return true
+	}
+
+	// King + single minor piece vs King
+	if totalMinor == 1 {
+		return true
+	}
+
+	// King + Bishop vs King + Bishop on same color squares
+	if knights == 0 && bishops == 2 && allBishopsSameColor {
+		return true
+	}
+
+	return false
+}
+
 // Square returns the piece in a square.
 // The square is represented by an algebraic notation.
 //

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -288,7 +288,7 @@ func (c *Chess) IsInsufficientMaterial() bool {
 				continue
 			}
 
-			pieceType := piece &^ (gochess.White | gochess.Black)
+			pieceType := gochess.PieceType(piece)
 			switch pieceType {
 			case gochess.King:
 				// Kings are always present, skip them.

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -619,7 +619,22 @@ func TestIsInsufficientMaterial(t *testing.T) {
 		},
 		{
 			name: "King + Pawn vs King",
-			fen:  "4k3/8/8/8/8/4P3/4K3 w - - 0 1",
+			fen:  "4k3/8/8/8/8/8/4P3/4K3 w - - 0 1",
+			want: false,
+		},
+		{
+			name: "King + Two Knights vs King is sufficient",
+			fen:  "4k3/8/8/8/8/8/8/4KNN1 w - - 0 1",
+			want: false,
+		},
+		{
+			name: "King + Knight vs King + Knight is sufficient",
+			fen:  "4k1n1/8/8/8/8/8/8/4K1N1 w - - 0 1",
+			want: false,
+		},
+		{
+			name: "King + Bishop vs King + Knight is sufficient",
+			fen:  "4k1n1/8/8/8/8/8/8/4K1B1 w - - 0 1",
 			want: false,
 		},
 	}

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -571,6 +571,68 @@ func (b *errorBoard) SetSquare(_ gochess.Coordinate, _ gochess.Piece) error { re
 func (b *errorBoard) Square(_ gochess.Coordinate) (gochess.Piece, error)    { return 0, b.squareErr }
 func (b *errorBoard) Width() int                                             { return 8 }
 
+func TestIsInsufficientMaterial(t *testing.T) {
+	tests := []struct {
+		name string
+		fen  string
+		want bool
+	}{
+		{
+			name: "Default position",
+			fen:  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			want: false,
+		},
+		{
+			name: "King vs King",
+			fen:  "4k3/8/8/8/8/8/8/4K3 w - - 0 1",
+			want: true,
+		},
+		{
+			name: "King + Knight vs King",
+			fen:  "4k3/8/8/8/8/8/8/4K1N1 w - - 0 1",
+			want: true,
+		},
+		{
+			name: "King + Bishop vs King",
+			fen:  "4k3/8/8/8/8/8/8/4K1B1 w - - 0 1",
+			want: true,
+		},
+		{
+			name: "King + Bishop vs King + Bishop same color squares",
+			fen:  "4kb2/8/8/8/8/8/8/4K1B1 w - - 0 1",
+			want: true,
+		},
+		{
+			name: "King + Bishop vs King + Bishop different color squares",
+			fen:  "4k1b1/8/8/8/8/8/8/4K1B1 w - - 0 1",
+			want: false,
+		},
+		{
+			name: "King + Rook vs King",
+			fen:  "4k3/8/8/8/8/8/8/4K2R w - - 0 1",
+			want: false,
+		},
+		{
+			name: "King + Queen vs King",
+			fen:  "4k3/8/8/8/8/8/8/3QK3 w - - 0 1",
+			want: false,
+		},
+		{
+			name: "King + Pawn vs King",
+			fen:  "4k3/8/8/8/8/4P3/4K3 w - - 0 1",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := chess.New(chess.WithFEN(tt.fen))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, c.IsInsufficientMaterial())
+		})
+	}
+}
+
 func TestMakeMove_ScholarMate(t *testing.T) {
 	// Arrange
 	c, err := chess.New()


### PR DESCRIPTION
## Summary
- Add `IsInsufficientMaterial()` method to `Chess` that scans the board and returns `true` when neither side has enough material to checkmate
- Detects: King vs King, King+Knight vs King, King+Bishop vs King, and King+Bishop vs King+Bishop (same color squares)
- Includes table-driven tests covering all insufficient material cases plus sufficient material cases (rook, queen, pawn)

## Test plan
- [x] `go test ./...` passes
- [x] Verified K vs K returns true
- [x] Verified K+N vs K returns true
- [x] Verified K+B vs K returns true
- [x] Verified K+B vs K+B same color squares returns true
- [x] Verified K+B vs K+B different color squares returns false
- [x] Verified K+R, K+Q, K+P vs K all return false
- [x] Verified default starting position returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)