### PR TITLE
Add PGN export and parsing support

### DIFF
--- a/chess/README.md
+++ b/chess/README.md
@@ -40,8 +40,9 @@ func (c *Chess) IsStalemate() bool
 func (c *Chess) IsFiftyMoveRule() bool
 func (c *Chess) LoadPosition(fen string) error
 func (c *Chess) Clone() *Chess
-func (c *Chess) PGN(tags PGNTags) (string, error)
-func ParsePGN(pgn string) (PGNTags, []string, error)
+func (c *Chess) PGN(tags pgn.PGNTags) string
+// Parse and PGNTags live in the chess/pgn sub-package:
+// pgn.Parse(pgnStr string) (pgn.PGNTags, []string, error)
 ```
 
 ### Core Functions
@@ -70,9 +71,9 @@ func ParsePGN(pgn string) (PGNTags, []string, error)
 
 - `Clone() *Chess`: Returns a copy of the chess game.
 
-- `PGN(tags PGNTags) (string, error)`: Generates a PGN string from the current game's move history and the provided tags (event, site, date, white/black player names, result).
+- `PGN(tags pgn.PGNTags) string`: Generates a PGN string from the current game's move history and the provided tags (event, site, date, white/black player names, result). `PGNTags` and the result constants (`ResultWhiteWins`, `ResultBlackWins`, `ResultDraw`, `ResultOngoing`) are defined in the `chess/pgn` sub-package.
 
-- `ParsePGN(pgn string) (PGNTags, []string, error)`: Parses a PGN string and returns the tag pairs and move list in UCI format.
+- `pgn.Parse(pgnStr string) (pgn.PGNTags, []string, error)`: Parses a PGN string and returns the tag pairs and move list in UCI format. Lives in the `chess/pgn` sub-package.
 
 ## Creating a Chess Game
 

--- a/chess/README.md
+++ b/chess/README.md
@@ -40,6 +40,8 @@ func (c *Chess) IsStalemate() bool
 func (c *Chess) IsFiftyMoveRule() bool
 func (c *Chess) LoadPosition(fen string) error
 func (c *Chess) Clone() *Chess
+func (c *Chess) PGN(tags PGNTags) (string, error)
+func ParsePGN(pgn string) (PGNTags, []string, error)
 ```
 
 ### Core Functions
@@ -67,6 +69,10 @@ func (c *Chess) Clone() *Chess
 - `LoadPosition(fen string) error`: Sets up the board according to the provided FEN string.
 
 - `Clone() *Chess`: Returns a copy of the chess game.
+
+- `PGN(tags PGNTags) (string, error)`: Generates a PGN string from the current game's move history and the provided tags (event, site, date, white/black player names, result).
+
+- `ParsePGN(pgn string) (PGNTags, []string, error)`: Parses a PGN string and returns the tag pairs and move list in UCI format.
 
 ## Creating a Chess Game
 

--- a/chess/pgn.go
+++ b/chess/pgn.go
@@ -1,0 +1,271 @@
+package chess
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/RchrdHndrcks/gochess"
+)
+
+// PGNTags represents the seven required tag pairs in a PGN file.
+type PGNTags struct {
+	Event  string
+	Site   string
+	Date   string
+	Round  string
+	White  string
+	Black  string
+	Result string
+}
+
+// ToPGN generates a PGN string from the current game state.
+//
+// It writes the seven required tag pairs and the move text using UCI notation.
+// Empty tag values default to "?". The Result tag is determined automatically
+// if not provided: "1-0" or "0-1" for checkmate, "1/2-1/2" for stalemate,
+// and "*" for an ongoing game.
+func (c *Chess) ToPGN(tags PGNTags) string {
+	var sb strings.Builder
+
+	result := c.determineResult(tags.Result)
+
+	// Write tag pairs.
+	writeTag(&sb, "Event", tagValue(tags.Event))
+	writeTag(&sb, "Site", tagValue(tags.Site))
+	writeTag(&sb, "Date", tagValue(tags.Date))
+	writeTag(&sb, "Round", tagValue(tags.Round))
+	writeTag(&sb, "White", tagValue(tags.White))
+	writeTag(&sb, "Black", tagValue(tags.Black))
+	writeTag(&sb, "Result", result)
+
+	sb.WriteString("\n")
+
+	// Write moves.
+	moveText := c.buildMoveText(result)
+	sb.WriteString(wrapLines(moveText, 80))
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+// ParsePGN parses a PGN string and returns the tags and a list of move strings.
+//
+// It extracts the seven standard tag pairs from bracket-enclosed headers and
+// parses the move text section, ignoring comments, variations, and NAGs.
+func ParsePGN(pgn string) (PGNTags, []string, error) {
+	tags := PGNTags{}
+	lines := strings.Split(pgn, "\n")
+
+	moveTextStart := 0
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			moveTextStart = i + 1
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			if err := parseTag(&tags, line); err != nil {
+				return PGNTags{}, nil, fmt.Errorf("failed to parse tag: %w", err)
+			}
+			moveTextStart = i + 1
+		} else {
+			// First non-tag, non-empty line starts the move text.
+			moveTextStart = i
+			break
+		}
+	}
+
+	moveText := strings.Join(lines[moveTextStart:], " ")
+	moves := parseMoveText(moveText)
+
+	return tags, moves, nil
+}
+
+// determineResult returns the game result string.
+func (c *Chess) determineResult(provided string) string {
+	if provided != "" {
+		return provided
+	}
+
+	if c.checkmate {
+		if c.turn == gochess.White {
+			return "0-1"
+		}
+		return "1-0"
+	}
+
+	if c.stalemate {
+		return "1/2-1/2"
+	}
+
+	return "*"
+}
+
+// buildMoveText builds the move text from the game history.
+func (c *Chess) buildMoveText(result string) string {
+	var parts []string
+	for i, ctx := range c.history {
+		moveNum := i/2 + 1
+		if i%2 == 0 {
+			parts = append(parts, fmt.Sprintf("%d.", moveNum))
+		}
+		parts = append(parts, ctx.move)
+	}
+	parts = append(parts, result)
+	return strings.Join(parts, " ")
+}
+
+// wrapLines wraps text at the given column width, breaking at spaces.
+func wrapLines(text string, maxWidth int) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	lineLen := 0
+
+	for i, word := range words {
+		if i == 0 {
+			sb.WriteString(word)
+			lineLen = len(word)
+			continue
+		}
+
+		if lineLen+1+len(word) > maxWidth {
+			sb.WriteString("\n")
+			sb.WriteString(word)
+			lineLen = len(word)
+		} else {
+			sb.WriteString(" ")
+			sb.WriteString(word)
+			lineLen += 1 + len(word)
+		}
+	}
+
+	return sb.String()
+}
+
+// writeTag writes a PGN tag pair to the builder.
+func writeTag(sb *strings.Builder, name, value string) {
+	sb.WriteString(fmt.Sprintf("[%s \"%s\"]\n", name, value))
+}
+
+// tagValue returns the value or "?" if empty.
+func tagValue(v string) string {
+	if v == "" {
+		return "?"
+	}
+	return v
+}
+
+// parseTag parses a single PGN tag line and sets it on the tags struct.
+func parseTag(tags *PGNTags, line string) error {
+	// Format: [Name "Value"]
+	line = strings.TrimPrefix(line, "[")
+	line = strings.TrimSuffix(line, "]")
+
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid tag format: %s", line)
+	}
+
+	name := parts[0]
+	value := strings.Trim(parts[1], "\"")
+
+	switch name {
+	case "Event":
+		tags.Event = value
+	case "Site":
+		tags.Site = value
+	case "Date":
+		tags.Date = value
+	case "Round":
+		tags.Round = value
+	case "White":
+		tags.White = value
+	case "Black":
+		tags.Black = value
+	case "Result":
+		tags.Result = value
+	}
+
+	return nil
+}
+
+// parseMoveText parses the move text portion of a PGN string.
+// It ignores comments (enclosed in {} or starting with ;),
+// variations (enclosed in ()), and NAGs (starting with $).
+func parseMoveText(text string) []string {
+	var moves []string
+
+	// Remove brace comments.
+	for {
+		start := strings.Index(text, "{")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(text[start:], "}")
+		if end == -1 {
+			break
+		}
+		text = text[:start] + text[start+end+1:]
+	}
+
+	// Remove variations (parenthesized).
+	for {
+		start := strings.Index(text, "(")
+		if start == -1 {
+			break
+		}
+		depth := 1
+		end := start + 1
+		for end < len(text) && depth > 0 {
+			if text[end] == '(' {
+				depth++
+			} else if text[end] == ')' {
+				depth--
+			}
+			end++
+		}
+		text = text[:start] + text[end:]
+	}
+
+	tokens := strings.Fields(text)
+	results := map[string]bool{
+		"1-0":     true,
+		"0-1":     true,
+		"1/2-1/2": true,
+		"*":       true,
+	}
+
+	for _, token := range tokens {
+		// Skip move numbers (e.g., "1.", "12.").
+		if strings.HasSuffix(token, ".") {
+			continue
+		}
+		// Also skip move numbers like "1..." for black moves.
+		if strings.Contains(token, "...") {
+			continue
+		}
+		// Skip NAGs.
+		if strings.HasPrefix(token, "$") {
+			continue
+		}
+		// Skip semicolon comments (rest of line, but we joined lines).
+		if strings.HasPrefix(token, ";") {
+			continue
+		}
+		// Skip result tokens.
+		if results[token] {
+			continue
+		}
+		// Skip empty tokens.
+		if token == "" {
+			continue
+		}
+		moves = append(moves, token)
+	}
+
+	return moves
+}

--- a/chess/pgn.go
+++ b/chess/pgn.go
@@ -75,7 +75,15 @@ func ParsePGN(pgn string) (PGNTags, []string, error) {
 		}
 	}
 
-	moveText := strings.Join(lines[moveTextStart:], " ")
+	// Strip semicolon comments (rest-of-line) before joining.
+	cleanedLines := make([]string, 0, len(lines)-moveTextStart)
+	for _, l := range lines[moveTextStart:] {
+		if idx := strings.Index(l, ";"); idx >= 0 {
+			l = l[:idx]
+		}
+		cleanedLines = append(cleanedLines, l)
+	}
+	moveText := strings.Join(cleanedLines, " ")
 	moves := parseMoveText(moveText)
 
 	return tags, moves, nil
@@ -147,8 +155,11 @@ func wrapLines(text string, maxWidth int) string {
 }
 
 // writeTag writes a PGN tag pair to the builder.
+// It escapes backslashes and double quotes per PGN specification.
 func writeTag(sb *strings.Builder, name, value string) {
-	sb.WriteString(fmt.Sprintf("[%s \"%s\"]\n", name, value))
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	sb.WriteString(fmt.Sprintf("[%s \"%s\"]\n", name, escaped))
 }
 
 // tagValue returns the value or "?" if empty.
@@ -171,7 +182,14 @@ func parseTag(tags *PGNTags, line string) error {
 	}
 
 	name := parts[0]
-	value := strings.Trim(parts[1], "\"")
+	raw := parts[1]
+	// Strip surrounding quotes.
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		raw = raw[1 : len(raw)-1]
+	}
+	// Unescape per PGN specification.
+	value := strings.ReplaceAll(raw, `\"`, `"`)
+	value = strings.ReplaceAll(value, `\\`, `\`)
 
 	switch name {
 	case "Event":

--- a/chess/pgn.go
+++ b/chess/pgn.go
@@ -7,6 +7,14 @@ import (
 	"github.com/RchrdHndrcks/gochess"
 )
 
+// PGN result constants per the PGN specification.
+const (
+	ResultWhiteWins = "1-0"
+	ResultBlackWins = "0-1"
+	ResultDraw      = "1/2-1/2"
+	ResultOngoing   = "*"
+)
+
 // PGNTags represents the seven required tag pairs in a PGN file.
 type PGNTags struct {
 	Event  string
@@ -18,13 +26,13 @@ type PGNTags struct {
 	Result string
 }
 
-// ToPGN generates a PGN string from the current game state.
+// PGN generates a PGN string from the current game state.
 //
 // It writes the seven required tag pairs and the move text using UCI notation.
 // Empty tag values default to "?". The Result tag is determined automatically
 // if not provided: "1-0" or "0-1" for checkmate, "1/2-1/2" for stalemate,
 // and "*" for an ongoing game.
-func (c *Chess) ToPGN(tags PGNTags) string {
+func (c *Chess) PGN(tags PGNTags) string {
 	var sb strings.Builder
 
 	result := c.determineResult(tags.Result)
@@ -97,16 +105,16 @@ func (c *Chess) determineResult(provided string) string {
 
 	if c.checkmate {
 		if c.turn == gochess.White {
-			return "0-1"
+			return ResultBlackWins
 		}
-		return "1-0"
+		return ResultWhiteWins
 	}
 
 	if c.stalemate {
-		return "1/2-1/2"
+		return ResultDraw
 	}
 
-	return "*"
+	return ResultOngoing
 }
 
 // buildMoveText builds the move text from the game history.
@@ -251,10 +259,10 @@ func parseMoveText(text string) []string {
 
 	tokens := strings.Fields(text)
 	results := map[string]bool{
-		"1-0":     true,
-		"0-1":     true,
-		"1/2-1/2": true,
-		"*":       true,
+		ResultWhiteWins: true,
+		ResultBlackWins: true,
+		ResultDraw:      true,
+		ResultOngoing:   true,
 	}
 
 	for _, token := range tokens {

--- a/chess/pgn.go
+++ b/chess/pgn.go
@@ -104,10 +104,13 @@ func wrapLines(text string, maxWidth int) string {
 }
 
 // writeTag writes a PGN tag pair to the builder.
-// It escapes backslashes and double quotes per PGN specification.
+// It escapes backslashes and double quotes per PGN specification, and strips
+// carriage returns and newlines, which are not permitted inside tag values.
 func writeTag(sb *strings.Builder, name, value string) {
 	escaped := strings.ReplaceAll(value, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\r", "")
+	escaped = strings.ReplaceAll(escaped, "\n", "")
 	sb.WriteString(fmt.Sprintf("[%s \"%s\"]\n", name, escaped))
 }
 

--- a/chess/pgn.go
+++ b/chess/pgn.go
@@ -5,26 +5,8 @@ import (
 	"strings"
 
 	"github.com/RchrdHndrcks/gochess"
+	chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
 )
-
-// PGN result constants per the PGN specification.
-const (
-	ResultWhiteWins = "1-0"
-	ResultBlackWins = "0-1"
-	ResultDraw      = "1/2-1/2"
-	ResultOngoing   = "*"
-)
-
-// PGNTags represents the seven required tag pairs in a PGN file.
-type PGNTags struct {
-	Event  string
-	Site   string
-	Date   string
-	Round  string
-	White  string
-	Black  string
-	Result string
-}
 
 // PGN generates a PGN string from the current game state.
 //
@@ -32,7 +14,7 @@ type PGNTags struct {
 // Empty tag values default to "?". The Result tag is determined automatically
 // if not provided: "1-0" or "0-1" for checkmate, "1/2-1/2" for stalemate,
 // and "*" for an ongoing game.
-func (c *Chess) PGN(tags PGNTags) string {
+func (c *Chess) PGN(tags chesspgn.PGNTags) string {
 	var sb strings.Builder
 
 	result := c.determineResult(tags.Result)
@@ -56,47 +38,6 @@ func (c *Chess) PGN(tags PGNTags) string {
 	return sb.String()
 }
 
-// ParsePGN parses a PGN string and returns the tags and a list of move strings.
-//
-// It extracts the seven standard tag pairs from bracket-enclosed headers and
-// parses the move text section, ignoring comments, variations, and NAGs.
-func ParsePGN(pgn string) (PGNTags, []string, error) {
-	tags := PGNTags{}
-	lines := strings.Split(pgn, "\n")
-
-	moveTextStart := 0
-	for i, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			moveTextStart = i + 1
-			continue
-		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			if err := parseTag(&tags, line); err != nil {
-				return PGNTags{}, nil, fmt.Errorf("failed to parse tag: %w", err)
-			}
-			moveTextStart = i + 1
-		} else {
-			// First non-tag, non-empty line starts the move text.
-			moveTextStart = i
-			break
-		}
-	}
-
-	// Strip semicolon comments (rest-of-line) before joining.
-	cleanedLines := make([]string, 0, len(lines)-moveTextStart)
-	for _, l := range lines[moveTextStart:] {
-		if idx := strings.Index(l, ";"); idx >= 0 {
-			l = l[:idx]
-		}
-		cleanedLines = append(cleanedLines, l)
-	}
-	moveText := strings.Join(cleanedLines, " ")
-	moves := parseMoveText(moveText)
-
-	return tags, moves, nil
-}
-
 // determineResult returns the game result string.
 func (c *Chess) determineResult(provided string) string {
 	if provided != "" {
@@ -105,16 +46,16 @@ func (c *Chess) determineResult(provided string) string {
 
 	if c.checkmate {
 		if c.turn == gochess.White {
-			return ResultBlackWins
+			return chesspgn.ResultBlackWins
 		}
-		return ResultWhiteWins
+		return chesspgn.ResultWhiteWins
 	}
 
 	if c.stalemate {
-		return ResultDraw
+		return chesspgn.ResultDraw
 	}
 
-	return ResultOngoing
+	return chesspgn.ResultOngoing
 }
 
 // buildMoveText builds the move text from the game history.
@@ -176,122 +117,4 @@ func tagValue(v string) string {
 		return "?"
 	}
 	return v
-}
-
-// parseTag parses a single PGN tag line and sets it on the tags struct.
-func parseTag(tags *PGNTags, line string) error {
-	// Format: [Name "Value"]
-	line = strings.TrimPrefix(line, "[")
-	line = strings.TrimSuffix(line, "]")
-
-	parts := strings.SplitN(line, " ", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid tag format: %s", line)
-	}
-
-	name := parts[0]
-	raw := parts[1]
-	// Strip surrounding quotes.
-	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
-		raw = raw[1 : len(raw)-1]
-	}
-	// Unescape per PGN specification.
-	value := strings.ReplaceAll(raw, `\"`, `"`)
-	value = strings.ReplaceAll(value, `\\`, `\`)
-
-	switch name {
-	case "Event":
-		tags.Event = value
-	case "Site":
-		tags.Site = value
-	case "Date":
-		tags.Date = value
-	case "Round":
-		tags.Round = value
-	case "White":
-		tags.White = value
-	case "Black":
-		tags.Black = value
-	case "Result":
-		tags.Result = value
-	}
-
-	return nil
-}
-
-// parseMoveText parses the move text portion of a PGN string.
-// It ignores comments (enclosed in {} or starting with ;),
-// variations (enclosed in ()), and NAGs (starting with $).
-func parseMoveText(text string) []string {
-	var moves []string
-
-	// Remove brace comments.
-	for {
-		start := strings.Index(text, "{")
-		if start == -1 {
-			break
-		}
-		end := strings.Index(text[start:], "}")
-		if end == -1 {
-			break
-		}
-		text = text[:start] + text[start+end+1:]
-	}
-
-	// Remove variations (parenthesized).
-	for {
-		start := strings.Index(text, "(")
-		if start == -1 {
-			break
-		}
-		depth := 1
-		end := start + 1
-		for end < len(text) && depth > 0 {
-			if text[end] == '(' {
-				depth++
-			} else if text[end] == ')' {
-				depth--
-			}
-			end++
-		}
-		text = text[:start] + text[end:]
-	}
-
-	tokens := strings.Fields(text)
-	results := map[string]bool{
-		ResultWhiteWins: true,
-		ResultBlackWins: true,
-		ResultDraw:      true,
-		ResultOngoing:   true,
-	}
-
-	for _, token := range tokens {
-		// Skip move numbers (e.g., "1.", "12.").
-		if strings.HasSuffix(token, ".") {
-			continue
-		}
-		// Also skip move numbers like "1..." for black moves.
-		if strings.Contains(token, "...") {
-			continue
-		}
-		// Skip NAGs.
-		if strings.HasPrefix(token, "$") {
-			continue
-		}
-		// Skip semicolon comments (rest of line, but we joined lines).
-		if strings.HasPrefix(token, ";") {
-			continue
-		}
-		// Skip result tokens.
-		if results[token] {
-			continue
-		}
-		// Skip empty tokens.
-		if token == "" {
-			continue
-		}
-		moves = append(moves, token)
-	}
-
-	return moves
 }

--- a/chess/pgn/README.md
+++ b/chess/pgn/README.md
@@ -1,0 +1,152 @@
+# chess/pgn
+
+## Overview
+
+The `pgn` package provides types and parsing utilities for the [Portable Game
+Notation (PGN)](https://www.chessclub.com/help/PGN-spec) standard.
+
+It is a sub-package of `chess/` and has no dependency on the chess engine.
+This means it can be imported independently to inspect or process PGN data
+without instantiating a game.
+
+The companion generation function (`Chess.PGN`) lives in the parent `chess/`
+package because it reads the engine's internal move history.
+
+## Key Types
+
+### `PGNTags`
+
+```go
+type PGNTags struct {
+    Event  string
+    Site   string
+    Date   string
+    Round  string
+    White  string
+    Black  string
+    Result string
+}
+```
+
+Holds the seven required tag pairs defined by the PGN standard (the "Seven
+Tag Roster"). Empty fields in a generated PGN default to `"?"`.
+
+### Result constants
+
+```go
+const (
+    ResultWhiteWins = "1-0"
+    ResultBlackWins = "0-1"
+    ResultDraw      = "1/2-1/2"
+    ResultOngoing   = "*"
+)
+```
+
+## API
+
+```go
+func Parse(pgn string) (PGNTags, []string, error)
+```
+
+### `Parse`
+
+Parses a PGN string and returns:
+
+1. The seven tag pairs extracted from the bracket-enclosed headers.
+2. A slice of moves in the same notation used in the move text (UCI for games
+   produced by this library).
+3. An error if a tag line is malformed.
+
+The parser ignores:
+- Brace comments `{ ... }`
+- Semicolon rest-of-line comments `; ...`
+- Variations `( ... )` (including nested)
+- NAGs (e.g. `$1`, `$18`)
+- Move numbers and result tokens
+
+## Usage examples
+
+### Parse a PGN file
+
+```go
+import (
+    chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
+)
+
+pgnText := `[Event "World Championship"]
+[Site "Reykjavik"]
+[Date "1972.07.11"]
+[Round "1"]
+[White "Spassky"]
+[Black "Fischer"]
+[Result "1-0"]
+
+1. d4 Nf6 2. c4 e6 3. Nf3 1-0
+`
+
+tags, moves, err := chesspgn.Parse(pgnText)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println(tags.White)  // Spassky
+fmt.Println(tags.Black)  // Fischer
+fmt.Println(moves)       // [d4 Nf6 c4 e6 Nf3]
+```
+
+### Generate and round-trip a game
+
+```go
+import (
+    "github.com/RchrdHndrcks/gochess/chess"
+    chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
+)
+
+game, _ := chess.New()
+game.MakeMove("e2e4")
+game.MakeMove("e7e5")
+game.MakeMove("g1f3")
+
+tags := chesspgn.PGNTags{
+    Event: "My Game",
+    White: "Alice",
+    Black: "Bob",
+}
+pgnText := game.PGN(tags)
+
+// Parse it back
+parsedTags, parsedMoves, _ := chesspgn.Parse(pgnText)
+fmt.Println(parsedTags.Event) // My Game
+fmt.Println(parsedMoves)      // [e2e4 e7e5 g1f3]
+```
+
+### Check draw/win result constants
+
+```go
+if tags.Result == chesspgn.ResultDraw {
+    fmt.Println("The game was drawn.")
+}
+```
+
+## PGN escaping rules
+
+Tag values are escaped per the PGN specification:
+
+| Character | Escaped as |
+|-----------|------------|
+| `\`       | `\\`       |
+| `"`       | `\"`       |
+| `\n`, `\r` | stripped  |
+
+`Parse` reverses the escaping when reading tag values back.
+
+## Dependencies
+
+- Standard library only (`fmt`, `strings`).
+
+## Interactions with other packages
+
+| Package | Relationship |
+|---------|-------------|
+| `chess/` | Imports `chess/pgn` for `PGNTags` and result constants. Provides `Chess.PGN()` for generation. |
+| `gochess` (root) | No direct dependency. |

--- a/chess/pgn/pgn.go
+++ b/chess/pgn/pgn.go
@@ -1,0 +1,186 @@
+// Package pgn provides types and parsing utilities for the Portable Game
+// Notation (PGN) standard.
+package pgn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PGN result constants per the PGN specification.
+const (
+	ResultWhiteWins = "1-0"
+	ResultBlackWins = "0-1"
+	ResultDraw      = "1/2-1/2"
+	ResultOngoing   = "*"
+)
+
+// PGNTags represents the seven required tag pairs in a PGN file.
+type PGNTags struct {
+	Event  string
+	Site   string
+	Date   string
+	Round  string
+	White  string
+	Black  string
+	Result string
+}
+
+// Parse parses a PGN string and returns the tags and a list of move strings.
+//
+// It extracts the seven standard tag pairs from bracket-enclosed headers and
+// parses the move text section, ignoring comments, variations, and NAGs.
+func Parse(pgn string) (PGNTags, []string, error) {
+	tags := PGNTags{}
+	lines := strings.Split(pgn, "\n")
+
+	moveTextStart := 0
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			moveTextStart = i + 1
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			if err := parseTag(&tags, line); err != nil {
+				return PGNTags{}, nil, fmt.Errorf("failed to parse tag: %w", err)
+			}
+			moveTextStart = i + 1
+		} else {
+			// First non-tag, non-empty line starts the move text.
+			moveTextStart = i
+			break
+		}
+	}
+
+	// Strip semicolon comments (rest-of-line) before joining.
+	cleanedLines := make([]string, 0, len(lines)-moveTextStart)
+	for _, l := range lines[moveTextStart:] {
+		if idx := strings.Index(l, ";"); idx >= 0 {
+			l = l[:idx]
+		}
+		cleanedLines = append(cleanedLines, l)
+	}
+	moveText := strings.Join(cleanedLines, " ")
+	moves := parseMoveText(moveText)
+
+	return tags, moves, nil
+}
+
+// parseTag parses a single PGN tag line and sets it on the tags struct.
+func parseTag(tags *PGNTags, line string) error {
+	// Format: [Name "Value"]
+	line = strings.TrimPrefix(line, "[")
+	line = strings.TrimSuffix(line, "]")
+
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid tag format: %s", line)
+	}
+
+	name := parts[0]
+	raw := parts[1]
+	// Strip surrounding quotes.
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		raw = raw[1 : len(raw)-1]
+	}
+	// Unescape per PGN specification.
+	value := strings.ReplaceAll(raw, `\"`, `"`)
+	value = strings.ReplaceAll(value, `\\`, `\`)
+
+	switch name {
+	case "Event":
+		tags.Event = value
+	case "Site":
+		tags.Site = value
+	case "Date":
+		tags.Date = value
+	case "Round":
+		tags.Round = value
+	case "White":
+		tags.White = value
+	case "Black":
+		tags.Black = value
+	case "Result":
+		tags.Result = value
+	}
+
+	return nil
+}
+
+// parseMoveText parses the move text portion of a PGN string.
+// It ignores comments (enclosed in {} or starting with ;),
+// variations (enclosed in ()), and NAGs (starting with $).
+func parseMoveText(text string) []string {
+	var moves []string
+
+	// Remove brace comments.
+	for {
+		start := strings.Index(text, "{")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(text[start:], "}")
+		if end == -1 {
+			break
+		}
+		text = text[:start] + text[start+end+1:]
+	}
+
+	// Remove variations (parenthesized).
+	for {
+		start := strings.Index(text, "(")
+		if start == -1 {
+			break
+		}
+		depth := 1
+		end := start + 1
+		for end < len(text) && depth > 0 {
+			if text[end] == '(' {
+				depth++
+			} else if text[end] == ')' {
+				depth--
+			}
+			end++
+		}
+		text = text[:start] + text[end:]
+	}
+
+	tokens := strings.Fields(text)
+	results := map[string]bool{
+		ResultWhiteWins: true,
+		ResultBlackWins: true,
+		ResultDraw:      true,
+		ResultOngoing:   true,
+	}
+
+	for _, token := range tokens {
+		// Skip move numbers (e.g., "1.", "12.").
+		if strings.HasSuffix(token, ".") {
+			continue
+		}
+		// Also skip move numbers like "1..." for black moves.
+		if strings.Contains(token, "...") {
+			continue
+		}
+		// Skip NAGs.
+		if strings.HasPrefix(token, "$") {
+			continue
+		}
+		// Skip semicolon comments (rest of line, but we joined lines).
+		if strings.HasPrefix(token, ";") {
+			continue
+		}
+		// Skip result tokens.
+		if results[token] {
+			continue
+		}
+		// Skip empty tokens.
+		if token == "" {
+			continue
+		}
+		moves = append(moves, token)
+	}
+
+	return moves
+}

--- a/chess/pgn/pgn_test.go
+++ b/chess/pgn/pgn_test.go
@@ -1,0 +1,94 @@
+package pgn_test
+
+import (
+	"testing"
+
+	chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Run("Simple PGN", func(t *testing.T) {
+		pgn := `[Event "Test"]
+[Site "Internet"]
+[Date "2026.03.17"]
+[Round "1"]
+[White "Alice"]
+[Black "Bob"]
+[Result "1-0"]
+
+1. e2e4 e7e5 2. f1c4 b8c6 3. d1h5 g8f6 4. h5f7 1-0
+`
+		tags, moves, err := chesspgn.Parse(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Test", tags.Event)
+		assert.Equal(t, "Internet", tags.Site)
+		assert.Equal(t, "2026.03.17", tags.Date)
+		assert.Equal(t, "1", tags.Round)
+		assert.Equal(t, "Alice", tags.White)
+		assert.Equal(t, "Bob", tags.Black)
+		assert.Equal(t, "1-0", tags.Result)
+
+		expectedMoves := []string{"e2e4", "e7e5", "f1c4", "b8c6", "d1h5", "g8f6", "h5f7"}
+		assert.Equal(t, expectedMoves, moves)
+	})
+
+	t.Run("PGN with brace comments and variations", func(t *testing.T) {
+		pgn := `[Event "?"]
+[Result "*"]
+
+1. e2e4 {Best move} e7e5 (1... d7d5 2. e4d5) 2. g1f3 $1 b8c6 *
+`
+		tags, moves, err := chesspgn.Parse(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "?", tags.Event)
+		assert.Equal(t, "*", tags.Result)
+
+		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
+		assert.Equal(t, expectedMoves, moves)
+	})
+
+	t.Run("PGN with semicolon comments", func(t *testing.T) {
+		pgn := `[Event "?"]
+[Result "*"]
+
+1. e2e4 e7e5 ; this is a comment
+2. g1f3 b8c6 *
+`
+		_, moves, err := chesspgn.Parse(pgn)
+		require.NoError(t, err)
+
+		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
+		assert.Equal(t, expectedMoves, moves)
+	})
+
+	t.Run("Empty move text", func(t *testing.T) {
+		pgn := `[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+*
+`
+		tags, moves, err := chesspgn.Parse(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "?", tags.Event)
+		assert.Equal(t, "*", tags.Result)
+		assert.Empty(t, moves)
+	})
+
+	t.Run("Tag values with special characters roundtrip", func(t *testing.T) {
+		// Manually construct escaped PGN and verify unescaping.
+		pgn := "[Event \"He said \\\"hello\\\"\"]\n[Result \"*\"]\n\n*\n"
+		tags, _, err := chesspgn.Parse(pgn)
+		require.NoError(t, err)
+		assert.Equal(t, "He said \"hello\"", tags.Event)
+	})
+}

--- a/chess/pgn_test.go
+++ b/chess/pgn_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestToPGN(t *testing.T) {
+func TestPGN(t *testing.T) {
 	t.Run("Empty game with default tags", func(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)
 
-		pgn := c.ToPGN(chess.PGNTags{})
+		pgn := c.PGN(chess.PGNTags{})
 
 		assert.Contains(t, pgn, `[Event "?"]`)
 		assert.Contains(t, pgn, `[Site "?"]`)
@@ -23,7 +23,10 @@ func TestToPGN(t *testing.T) {
 		assert.Contains(t, pgn, `[White "?"]`)
 		assert.Contains(t, pgn, `[Black "?"]`)
 		assert.Contains(t, pgn, `[Result "*"]`)
-		assert.True(t, strings.HasSuffix(strings.TrimSpace(pgn), "*"))
+		parsedTags, parsedMoves, parseErr := chess.ParsePGN(pgn)
+		require.NoError(t, parseErr)
+		assert.Equal(t, chess.ResultOngoing, parsedTags.Result)
+		assert.Empty(t, parsedMoves)
 	})
 
 	t.Run("Empty game with custom tags", func(t *testing.T) {
@@ -38,7 +41,7 @@ func TestToPGN(t *testing.T) {
 			White: "Player1",
 			Black: "Player2",
 		}
-		pgn := c.ToPGN(tags)
+		pgn := c.PGN(tags)
 
 		assert.Contains(t, pgn, `[Event "Test Tournament"]`)
 		assert.Contains(t, pgn, `[Site "Internet"]`)
@@ -60,21 +63,19 @@ func TestToPGN(t *testing.T) {
 
 		require.True(t, c.IsCheckmate())
 
-		pgn := c.ToPGN(chess.PGNTags{})
+		pgn := c.PGN(chess.PGNTags{})
 
-		assert.Contains(t, pgn, `[Result "1-0"]`)
-		assert.Contains(t, pgn, "1. e2e4 e7e5")
-		assert.Contains(t, pgn, "2. f1c4 b8c6")
-		assert.Contains(t, pgn, "3. d1h5 g8f6")
-		assert.Contains(t, pgn, "4. h5f7")
-		assert.True(t, strings.HasSuffix(strings.TrimSpace(pgn), "1-0"))
+		parsedTags, parsedMoves, parseErr := chess.ParsePGN(pgn)
+		require.NoError(t, parseErr)
+		assert.Equal(t, chess.ResultWhiteWins, parsedTags.Result)
+		assert.Equal(t, []string{"e2e4", "e7e5", "f1c4", "b8c6", "d1h5", "g8f6", "h5f7"}, parsedMoves)
 	})
 
 	t.Run("Line wrapping", func(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)
 
-		pgn := c.ToPGN(chess.PGNTags{})
+		pgn := c.PGN(chess.PGNTags{})
 
 		for _, line := range strings.Split(pgn, "\n") {
 			assert.LessOrEqual(t, len(line), 80, "line exceeds 80 characters: %s", line)
@@ -89,7 +90,7 @@ func TestToPGN(t *testing.T) {
 			Event: "He said \"hello\"",
 			Site:  "path\\to\\file",
 		}
-		pgn := c.ToPGN(tags)
+		pgn := c.PGN(tags)
 
 		assert.Contains(t, pgn, "[Event \"He said \\\"hello\\\"\"]")
 		assert.Contains(t, pgn, "[Site \"path\\\\to\\\\file\"]")
@@ -194,7 +195,7 @@ func TestPGNRoundtrip(t *testing.T) {
 			White: "W",
 			Black: "B",
 		}
-		pgn := c.ToPGN(tags)
+		pgn := c.PGN(tags)
 
 		parsedTags, parsedMoves, err := chess.ParsePGN(pgn)
 		require.NoError(t, err)

--- a/chess/pgn_test.go
+++ b/chess/pgn_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/RchrdHndrcks/gochess/chess"
+	chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +15,7 @@ func TestPGN(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)
 
-		pgn := c.PGN(chess.PGNTags{})
+		pgn := c.PGN(chesspgn.PGNTags{})
 
 		assert.Contains(t, pgn, `[Event "?"]`)
 		assert.Contains(t, pgn, `[Site "?"]`)
@@ -23,9 +24,9 @@ func TestPGN(t *testing.T) {
 		assert.Contains(t, pgn, `[White "?"]`)
 		assert.Contains(t, pgn, `[Black "?"]`)
 		assert.Contains(t, pgn, `[Result "*"]`)
-		parsedTags, parsedMoves, parseErr := chess.ParsePGN(pgn)
+		parsedTags, parsedMoves, parseErr := chesspgn.Parse(pgn)
 		require.NoError(t, parseErr)
-		assert.Equal(t, chess.ResultOngoing, parsedTags.Result)
+		assert.Equal(t, chesspgn.ResultOngoing, parsedTags.Result)
 		assert.Empty(t, parsedMoves)
 	})
 
@@ -33,7 +34,7 @@ func TestPGN(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)
 
-		tags := chess.PGNTags{
+		tags := chesspgn.PGNTags{
 			Event: "Test Tournament",
 			Site:  "Internet",
 			Date:  "2026.03.17",
@@ -63,11 +64,11 @@ func TestPGN(t *testing.T) {
 
 		require.True(t, c.IsCheckmate())
 
-		pgn := c.PGN(chess.PGNTags{})
+		pgn := c.PGN(chesspgn.PGNTags{})
 
-		parsedTags, parsedMoves, parseErr := chess.ParsePGN(pgn)
+		parsedTags, parsedMoves, parseErr := chesspgn.Parse(pgn)
 		require.NoError(t, parseErr)
-		assert.Equal(t, chess.ResultWhiteWins, parsedTags.Result)
+		assert.Equal(t, chesspgn.ResultWhiteWins, parsedTags.Result)
 		assert.Equal(t, []string{"e2e4", "e7e5", "f1c4", "b8c6", "d1h5", "g8f6", "h5f7"}, parsedMoves)
 	})
 
@@ -75,7 +76,7 @@ func TestPGN(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)
 
-		pgn := c.PGN(chess.PGNTags{})
+		pgn := c.PGN(chesspgn.PGNTags{})
 
 		for _, line := range strings.Split(pgn, "\n") {
 			assert.LessOrEqual(t, len(line), 80, "line exceeds 80 characters: %s", line)
@@ -86,7 +87,7 @@ func TestPGN(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)
 
-		tags := chess.PGNTags{
+		tags := chesspgn.PGNTags{
 			Event: "He said \"hello\"",
 			Site:  "path\\to\\file",
 		}
@@ -96,87 +97,10 @@ func TestPGN(t *testing.T) {
 		assert.Contains(t, pgn, "[Site \"path\\\\to\\\\file\"]")
 
 		// Roundtrip: parse back and verify unescaped values.
-		parsedTags, _, err := chess.ParsePGN(pgn)
+		parsedTags, _, err := chesspgn.Parse(pgn)
 		require.NoError(t, err)
 		assert.Equal(t, "He said \"hello\"", parsedTags.Event)
 		assert.Equal(t, "path\\to\\file", parsedTags.Site)
-	})
-}
-
-func TestParsePGN(t *testing.T) {
-	t.Run("Simple PGN", func(t *testing.T) {
-		pgn := `[Event "Test"]
-[Site "Internet"]
-[Date "2026.03.17"]
-[Round "1"]
-[White "Alice"]
-[Black "Bob"]
-[Result "1-0"]
-
-1. e2e4 e7e5 2. f1c4 b8c6 3. d1h5 g8f6 4. h5f7 1-0
-`
-		tags, moves, err := chess.ParsePGN(pgn)
-		require.NoError(t, err)
-
-		assert.Equal(t, "Test", tags.Event)
-		assert.Equal(t, "Internet", tags.Site)
-		assert.Equal(t, "2026.03.17", tags.Date)
-		assert.Equal(t, "1", tags.Round)
-		assert.Equal(t, "Alice", tags.White)
-		assert.Equal(t, "Bob", tags.Black)
-		assert.Equal(t, "1-0", tags.Result)
-
-		expectedMoves := []string{"e2e4", "e7e5", "f1c4", "b8c6", "d1h5", "g8f6", "h5f7"}
-		assert.Equal(t, expectedMoves, moves)
-	})
-
-	t.Run("PGN with comments and variations", func(t *testing.T) {
-		pgn := `[Event "?"]
-[Result "*"]
-
-1. e2e4 {Best move} e7e5 (1... d7d5 2. e4d5) 2. g1f3 $1 b8c6 *
-`
-		tags, moves, err := chess.ParsePGN(pgn)
-		require.NoError(t, err)
-
-		assert.Equal(t, "?", tags.Event)
-		assert.Equal(t, "*", tags.Result)
-
-		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
-		assert.Equal(t, expectedMoves, moves)
-	})
-
-	t.Run("PGN with semicolon comments", func(t *testing.T) {
-		pgn := `[Event "?"]
-[Result "*"]
-
-1. e2e4 e7e5 ; this is a comment
-2. g1f3 b8c6 *
-`
-		_, moves, err := chess.ParsePGN(pgn)
-		require.NoError(t, err)
-
-		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
-		assert.Equal(t, expectedMoves, moves)
-	})
-
-	t.Run("Empty PGN", func(t *testing.T) {
-		pgn := `[Event "?"]
-[Site "?"]
-[Date "?"]
-[Round "?"]
-[White "?"]
-[Black "?"]
-[Result "*"]
-
-*
-`
-		tags, moves, err := chess.ParsePGN(pgn)
-		require.NoError(t, err)
-
-		assert.Equal(t, "?", tags.Event)
-		assert.Equal(t, "*", tags.Result)
-		assert.Empty(t, moves)
 	})
 }
 
@@ -190,14 +114,14 @@ func TestPGNRoundtrip(t *testing.T) {
 			require.NoError(t, c.MakeMove(m))
 		}
 
-		tags := chess.PGNTags{
+		tags := chesspgn.PGNTags{
 			Event: "Roundtrip Test",
 			White: "W",
 			Black: "B",
 		}
 		pgn := c.PGN(tags)
 
-		parsedTags, parsedMoves, err := chess.ParsePGN(pgn)
+		parsedTags, parsedMoves, err := chesspgn.Parse(pgn)
 		require.NoError(t, err)
 
 		assert.Equal(t, "Roundtrip Test", parsedTags.Event)

--- a/chess/pgn_test.go
+++ b/chess/pgn_test.go
@@ -1,0 +1,174 @@
+package chess_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/RchrdHndrcks/gochess/chess"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToPGN(t *testing.T) {
+	t.Run("Empty game with default tags", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		pgn := c.ToPGN(chess.PGNTags{})
+
+		assert.Contains(t, pgn, `[Event "?"]`)
+		assert.Contains(t, pgn, `[Site "?"]`)
+		assert.Contains(t, pgn, `[Date "?"]`)
+		assert.Contains(t, pgn, `[Round "?"]`)
+		assert.Contains(t, pgn, `[White "?"]`)
+		assert.Contains(t, pgn, `[Black "?"]`)
+		assert.Contains(t, pgn, `[Result "*"]`)
+		assert.True(t, strings.HasSuffix(strings.TrimSpace(pgn), "*"))
+	})
+
+	t.Run("Empty game with custom tags", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		tags := chess.PGNTags{
+			Event: "Test Tournament",
+			Site:  "Internet",
+			Date:  "2026.03.17",
+			Round: "1",
+			White: "Player1",
+			Black: "Player2",
+		}
+		pgn := c.ToPGN(tags)
+
+		assert.Contains(t, pgn, `[Event "Test Tournament"]`)
+		assert.Contains(t, pgn, `[Site "Internet"]`)
+		assert.Contains(t, pgn, `[Date "2026.03.17"]`)
+		assert.Contains(t, pgn, `[Round "1"]`)
+		assert.Contains(t, pgn, `[White "Player1"]`)
+		assert.Contains(t, pgn, `[Black "Player2"]`)
+		assert.Contains(t, pgn, `[Result "*"]`)
+	})
+
+	t.Run("Scholar's mate", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		moves := []string{"e2e4", "e7e5", "f1c4", "b8c6", "d1h5", "g8f6", "h5f7"}
+		for _, m := range moves {
+			require.NoError(t, c.MakeMove(m))
+		}
+
+		require.True(t, c.IsCheckmate())
+
+		pgn := c.ToPGN(chess.PGNTags{})
+
+		assert.Contains(t, pgn, `[Result "1-0"]`)
+		assert.Contains(t, pgn, "1. e2e4 e7e5")
+		assert.Contains(t, pgn, "2. f1c4 b8c6")
+		assert.Contains(t, pgn, "3. d1h5 g8f6")
+		assert.Contains(t, pgn, "4. h5f7")
+		assert.True(t, strings.HasSuffix(strings.TrimSpace(pgn), "1-0"))
+	})
+
+	t.Run("Line wrapping", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		pgn := c.ToPGN(chess.PGNTags{})
+
+		for _, line := range strings.Split(pgn, "\n") {
+			assert.LessOrEqual(t, len(line), 80, "line exceeds 80 characters: %s", line)
+		}
+	})
+}
+
+func TestParsePGN(t *testing.T) {
+	t.Run("Simple PGN", func(t *testing.T) {
+		pgn := `[Event "Test"]
+[Site "Internet"]
+[Date "2026.03.17"]
+[Round "1"]
+[White "Alice"]
+[Black "Bob"]
+[Result "1-0"]
+
+1. e2e4 e7e5 2. f1c4 b8c6 3. d1h5 g8f6 4. h5f7 1-0
+`
+		tags, moves, err := chess.ParsePGN(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Test", tags.Event)
+		assert.Equal(t, "Internet", tags.Site)
+		assert.Equal(t, "2026.03.17", tags.Date)
+		assert.Equal(t, "1", tags.Round)
+		assert.Equal(t, "Alice", tags.White)
+		assert.Equal(t, "Bob", tags.Black)
+		assert.Equal(t, "1-0", tags.Result)
+
+		expectedMoves := []string{"e2e4", "e7e5", "f1c4", "b8c6", "d1h5", "g8f6", "h5f7"}
+		assert.Equal(t, expectedMoves, moves)
+	})
+
+	t.Run("PGN with comments and variations", func(t *testing.T) {
+		pgn := `[Event "?"]
+[Result "*"]
+
+1. e2e4 {Best move} e7e5 (1... d7d5 2. e4d5) 2. g1f3 $1 b8c6 *
+`
+		tags, moves, err := chess.ParsePGN(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "?", tags.Event)
+		assert.Equal(t, "*", tags.Result)
+
+		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
+		assert.Equal(t, expectedMoves, moves)
+	})
+
+	t.Run("Empty PGN", func(t *testing.T) {
+		pgn := `[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+*
+`
+		tags, moves, err := chess.ParsePGN(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "?", tags.Event)
+		assert.Equal(t, "*", tags.Result)
+		assert.Empty(t, moves)
+	})
+}
+
+func TestPGNRoundtrip(t *testing.T) {
+	t.Run("Play moves export parse verify", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		playedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6", "f1c4", "f8c5"}
+		for _, m := range playedMoves {
+			require.NoError(t, c.MakeMove(m))
+		}
+
+		tags := chess.PGNTags{
+			Event: "Roundtrip Test",
+			White: "W",
+			Black: "B",
+		}
+		pgn := c.ToPGN(tags)
+
+		parsedTags, parsedMoves, err := chess.ParsePGN(pgn)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Roundtrip Test", parsedTags.Event)
+		assert.Equal(t, "W", parsedTags.White)
+		assert.Equal(t, "B", parsedTags.Black)
+		assert.Equal(t, "*", parsedTags.Result)
+		assert.Equal(t, playedMoves, parsedMoves)
+	})
+}

--- a/chess/pgn_test.go
+++ b/chess/pgn_test.go
@@ -80,6 +80,26 @@ func TestToPGN(t *testing.T) {
 			assert.LessOrEqual(t, len(line), 80, "line exceeds 80 characters: %s", line)
 		}
 	})
+
+	t.Run("Tag values with special characters", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		tags := chess.PGNTags{
+			Event: "He said \"hello\"",
+			Site:  "path\\to\\file",
+		}
+		pgn := c.ToPGN(tags)
+
+		assert.Contains(t, pgn, "[Event \"He said \\\"hello\\\"\"]")
+		assert.Contains(t, pgn, "[Site \"path\\\\to\\\\file\"]")
+
+		// Roundtrip: parse back and verify unescaped values.
+		parsedTags, _, err := chess.ParsePGN(pgn)
+		require.NoError(t, err)
+		assert.Equal(t, "He said \"hello\"", parsedTags.Event)
+		assert.Equal(t, "path\\to\\file", parsedTags.Site)
+	})
 }
 
 func TestParsePGN(t *testing.T) {
@@ -120,6 +140,20 @@ func TestParsePGN(t *testing.T) {
 
 		assert.Equal(t, "?", tags.Event)
 		assert.Equal(t, "*", tags.Result)
+
+		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
+		assert.Equal(t, expectedMoves, moves)
+	})
+
+	t.Run("PGN with semicolon comments", func(t *testing.T) {
+		pgn := `[Event "?"]
+[Result "*"]
+
+1. e2e4 e7e5 ; this is a comment
+2. g1f3 b8c6 *
+`
+		_, moves, err := chess.ParsePGN(pgn)
+		require.NoError(t, err)
 
 		expectedMoves := []string{"e2e4", "e7e5", "g1f3", "b8c6"}
 		assert.Equal(t, expectedMoves, moves)

--- a/chess/pgn_test.go
+++ b/chess/pgn_test.go
@@ -83,6 +83,22 @@ func TestPGN(t *testing.T) {
 		}
 	})
 
+	t.Run("Newlines in tag values are stripped", func(t *testing.T) {
+		c, err := chess.New()
+		require.NoError(t, err)
+
+		tags := chesspgn.PGNTags{
+			Event: "line1\nline2",
+			Site:  "cr\r\ntest",
+		}
+		pgn := c.PGN(tags)
+
+		// Neither the event nor the site tag line should contain a raw newline
+		// or carriage return inside the quoted value.
+		assert.Contains(t, pgn, `[Event "line1line2"]`)
+		assert.Contains(t, pgn, `[Site "crtest"]`)
+	})
+
 	t.Run("Tag values with special characters", func(t *testing.T) {
 		c, err := chess.New()
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Add `PGNTags` struct and `ToPGN(tags PGNTags) string` method on `Chess` for exporting games in PGN format using UCI notation for moves
- Add `ParsePGN(pgn string) (PGNTags, []string, error)` function that parses PGN strings, extracting tag pairs and move lists while ignoring comments, variations, and NAGs
- Automatic result detection: checkmate resolves to "1-0" or "0-1", stalemate to "1/2-1/2", ongoing games to "*"
- Move text lines are wrapped at 80 characters per PGN specification

## Details

This is an intermediate step using UCI notation (e.g., `e2e4`) for moves since SAN notation support is not yet available. The PGN structure, metadata handling, and parsing logic are fully functional and can be updated to use SAN notation once it is implemented.

### New files
- `chess/pgn.go` - PGN export and parsing implementation
- `chess/pgn_test.go` - Tests covering empty games, Scholar's mate with checkmate detection, parsing with comments/variations/NAGs, and roundtrip export-parse verification

## Test plan

- [x] Empty game exports with default "?" tag values and "*" result
- [x] Custom tags are correctly written to PGN output
- [x] Scholar's mate game exports with "1-0" result and correct move numbering
- [x] Line wrapping respects 80-character limit
- [x] Parsing extracts all seven standard tag pairs
- [x] Parser ignores brace comments, parenthesized variations, and NAG annotations
- [x] Roundtrip: play moves, export to PGN, parse back, verify moves match
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)