### PR TITLE
fix: return copy from AvailableMoves and fix stale panic doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ The `Board` exports the following functions:
 
 ```go
 Width() int
-Square(c Coordinate) (int8, error)
-SetSquare(c Coordinate, p int8) error
+Square(c Coordinate) (Piece, error)
+SetSquare(c Coordinate, p Piece) error
 Clone() *Board
 ```
 

--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -269,8 +269,9 @@ func (c *Chess) updateCastlePossibilities() {
 
 // updateHalfMoves updates the half moves counter.
 //
-// It must be called after a move is made. If no move was made,
-// the function will panic.
+// It must be called after a move is made. If no move was made
+// (i.e. the history is empty), the function returns early without
+// modifying the counter.
 func (c *Chess) updateHalfMoves() {
 	if len(c.history) == 0 {
 		return

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -204,7 +204,7 @@ func (c *Chess) FEN() string {
 // It always returns a non nil slice. It could be empty if the position is
 // checkmate or stalemate.
 func (c *Chess) AvailableMoves() []string {
-	return c.moves
+	return slices.Clone(c.moves)
 }
 
 // MakeMove checks if the move is legal and makes it.


### PR DESCRIPTION
## Summary

- **Issue #41**: `AvailableMoves()` previously returned `c.moves` directly, allowing callers to mutate the internal slice. It now returns `slices.Clone(c.moves)` so the internal state is protected.
- **Issue #40**: `updateHalfMoves` had a stale doc comment claiming "the function will panic" when called with no history. A nil/empty check was already in place that returns early. The comment now accurately describes this behavior.

Closes #40
Closes #41

## Test plan

- [ ] `go test ./...` — existing tests pass (pre-existing unrelated build failure in `chess_test.go:551` exists on `main` and is not introduced by this PR)
- [ ] Verify `AvailableMoves()` callers cannot affect internal move list by mutating the returned slice
- [ ] Verify `updateHalfMoves` doc comment matches actual implementation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)