### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-04-04
+
+### Breaking Changes
+
+- [#28](https://github.com/RchrdHndrcks/gochess/pull/28) The `Board` interface now uses `gochess.Piece` instead of `int8` in `Square` and `SetSquare`. Custom board implementations must be updated accordingly.
+
+### Added
+
+- [#31](https://github.com/RchrdHndrcks/gochess/pull/31) `IsFiftyMoveRule() bool` — detects the fifty-move rule draw condition.
+- [#32](https://github.com/RchrdHndrcks/gochess/pull/32) `IsInsufficientMaterial() bool` — detects insufficient mating material per FIDE 5.2.2 (K vs K, K+N vs K, K+B vs K, K+B vs K+B same-color squares).
+- [#33](https://github.com/RchrdHndrcks/gochess/pull/33) `IsThreefoldRepetition() bool` — detects threefold repetition.
+- [#35](https://github.com/RchrdHndrcks/gochess/pull/35) `PieceType(p Piece) Piece` and `PieceColor(p Piece) Piece` helpers in the root package.
+- [#37](https://github.com/RchrdHndrcks/gochess/pull/37) PGN support: `(c *Chess) PGN(tags pgn.PGNTags) string` generates a PGN string; `chess/pgn` sub-package exposes `pgn.Parse()`, `pgn.PGNTags`, and result constants (`ResultWhiteWins`, `ResultBlackWins`, `ResultDraw`, `ResultOngoing`).
+- [#38](https://github.com/RchrdHndrcks/gochess/pull/38) SAN support: `(c *Chess) SAN(uciMove string) (string, error)` converts UCI to Standard Algebraic Notation; `(c *Chess) FromSAN(san string) (string, error)` converts SAN back to UCI.
+
+### Fixed
+
+- [#24](https://github.com/RchrdHndrcks/gochess/pull/24) `Chess.Square()` now propagates board errors instead of silently returning empty.
+- [#25](https://github.com/RchrdHndrcks/gochess/pull/25) Guard against panic in `updateHalfMoves` when history is empty.
+- [#27](https://github.com/RchrdHndrcks/gochess/pull/27) Rename `promotionPosibilities` → `promotionPossibilities` (typo fix).
+- [#39](https://github.com/RchrdHndrcks/gochess/pull/39) Castling is now correctly disallowed when the king is in check, passes through check, or lands in check (covers pawn attacks).
+- [#42](https://github.com/RchrdHndrcks/gochess/pull/42) `AvailableMoves()` returns a copy of the slice; callers can no longer mutate internal state. Fixed stale doc comment that incorrectly described a panic.
+
+### Changed
+
+- [#29](https://github.com/RchrdHndrcks/gochess/pull/29) Map lookups in the board adapter are validated; invalid keys return an error instead of a silent zero value.
+- [#36](https://github.com/RchrdHndrcks/gochess/pull/36) Renamed `move.go` to `notation.go` for clarity.
+
+### Documentation
+
+- [#30](https://github.com/RchrdHndrcks/gochess/pull/30) Documented that `Chess` is not safe for concurrent use.
+- [#34](https://github.com/RchrdHndrcks/gochess/pull/34) Added negative and edge-case tests for `MakeMove` and `UnmakeMove`.
+
 ## [1.3.0] - 2026-01-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#29](https://github.com/RchrdHndrcks/gochess/pull/29) Map lookups in the board adapter are validated; invalid keys return an error instead of a silent zero value.
+- [#29](https://github.com/RchrdHndrcks/gochess/pull/29) FEN parsing now validates `gochess.Pieces` map lookups; unknown piece characters return an error instead of a silent zero value.
 - [#36](https://github.com/RchrdHndrcks/gochess/pull/36) Renamed `move.go` to `notation.go` for clarity.
 
-### Documentation
+### Documentation / Tests
 
 - [#30](https://github.com/RchrdHndrcks/gochess/pull/30) Documented that `Chess` is not safe for concurrent use.
 - [#34](https://github.com/RchrdHndrcks/gochess/pull/34) Added negative and edge-case tests for `MakeMove` and `UnmakeMove`.


### PR DESCRIPTION
## v2.0.0

Documents and tags all changes merged since v1.3.0.

### Breaking Changes

- **[#28](https://github.com/RchrdHndrcks/gochess/pull/28)** `Board` interface now uses `gochess.Piece` instead of `int8` in `Square` and `SetSquare`. Custom board implementations must be updated.

### Added

- **[#31](https://github.com/RchrdHndrcks/gochess/pull/31)** `IsFiftyMoveRule() bool`
- **[#32](https://github.com/RchrdHndrcks/gochess/pull/32)** `IsInsufficientMaterial() bool` (FIDE 5.2.2)
- **[#33](https://github.com/RchrdHndrcks/gochess/pull/33)** `IsThreefoldRepetition() bool`
- **[#35](https://github.com/RchrdHndrcks/gochess/pull/35)** `PieceType(p Piece) Piece` and `PieceColor(p Piece) Piece` helpers
- **[#37](https://github.com/RchrdHndrcks/gochess/pull/37)** PGN support — `Chess.PGN()` + `chess/pgn` sub-package (`pgn.Parse`, `pgn.PGNTags`, result constants)
- **[#38](https://github.com/RchrdHndrcks/gochess/pull/38)** SAN support — `Chess.SAN()` and `Chess.FromSAN()`

### Fixed

- **[#24](https://github.com/RchrdHndrcks/gochess/pull/24)** `Chess.Square()` propagates board errors
- **[#25](https://github.com/RchrdHndrcks/gochess/pull/25)** Panic guard in `updateHalfMoves` when history is empty
- **[#27](https://github.com/RchrdHndrcks/gochess/pull/27)** Typo `promotionPosibilities` → `promotionPossibilities`
- **[#39](https://github.com/RchrdHndrcks/gochess/pull/39)** Castling disallowed when king is in check / passes through / lands in check
- **[#42](https://github.com/RchrdHndrcks/gochess/pull/42)** `AvailableMoves()` returns a copy; fixed stale panic doc comment

### Changed

- **[#29](https://github.com/RchrdHndrcks/gochess/pull/29)** Map lookups validated; invalid keys return errors
- **[#36](https://github.com/RchrdHndrcks/gochess/pull/36)** `move.go` renamed to `notation.go`

### Documentation / Tests

- **[#30](https://github.com/RchrdHndrcks/gochess/pull/30)** `Chess` documented as not concurrent-safe
- **[#34](https://github.com/RchrdHndrcks/gochess/pull/34)** Negative and edge-case tests for `MakeMove`/`UnmakeMove`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)