### PR TITLE
Use fresh game in checkSuffix to avoid shared board pointer

### DIFF
--- a/chess/san.go
+++ b/chess/san.go
@@ -179,7 +179,9 @@ func disambiguation(c *Chess, piece gochess.Piece, origin, target gochess.Coordi
 
 // checkSuffix determines if a move results in check or checkmate.
 func checkSuffix(c *Chess, uciMove string) string {
-	cloned := c.clone()
+	// Use LoadPosition to make a fresh game at the current FEN, avoiding
+	// any shared board pointer issue with clone().
+	cloned, _ := New(WithFEN(c.actualFEN), WithParallelism(1))
 	_ = cloned.MakeMove(uciMove)
 
 	if cloned.IsCheckmate() {


### PR DESCRIPTION
Calling `SAN(uci)` before `MakeMove(uci)` on the same `*Chess` corrupts the board: `clone()` sometimes doesn't produce a fully independent copy, so `cloned.MakeMove()` writes to the original board.

Fix: replace `c.clone()` with `New(WithFEN(c.actualFEN), WithParallelism(1))` — always produces a fully independent position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)