### PR TITLE
Handle error from New in checkSuffix, add mutation regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-04-04
+
+### Fixed
+
+- [#45](https://github.com/RchrdHndrcks/gochess/pull/45) `checkSuffix` now handles the error from `New(WithFEN(...))` and returns `""` instead of panicking on a nil game. Aligns the inline comment with what the code actually does. Adds regression test `TestSAN_DoesNotMutateBoard` verifying that calling `SAN()` does not alter the game's board state.
+
 ## [2.0.0] - 2026-04-04
 
 ### Breaking Changes

--- a/chess/san.go
+++ b/chess/san.go
@@ -179,9 +179,12 @@ func disambiguation(c *Chess, piece gochess.Piece, origin, target gochess.Coordi
 
 // checkSuffix determines if a move results in check or checkmate.
 func checkSuffix(c *Chess, uciMove string) string {
-	// Use LoadPosition to make a fresh game at the current FEN, avoiding
-	// any shared board pointer issue with clone().
-	cloned, _ := New(WithFEN(c.actualFEN), WithParallelism(1))
+	// Create a fresh game from the current FEN to avoid any shared board
+	// pointer issue with clone().
+	cloned, err := New(WithFEN(c.actualFEN), WithParallelism(1))
+	if err != nil || cloned == nil {
+		return ""
+	}
 	_ = cloned.MakeMove(uciMove)
 
 	if cloned.IsCheckmate() {

--- a/chess/san_test.go
+++ b/chess/san_test.go
@@ -306,3 +306,33 @@ func TestFromSAN(t *testing.T) {
 		}
 	})
 }
+
+// TestSAN_DoesNotMutateBoard verifies that calling SAN does not corrupt the
+// game's board state (regression for the checkSuffix clone() bug, PR #44).
+func TestSAN_DoesNotMutateBoard(t *testing.T) {
+	// Use a position where the move is checkmate so checkSuffix exercises
+	// the New(WithFEN(...)) path and produces a "#" suffix.
+	// Position: white Qf7, Kg6; black Kh8.
+	//   Qg7# — king on h8 is covered by Qg7 (diagonal), g8 covered by Qg7
+	//   (file), h7 covered by Qg7 (rank); Kg6 guards g7 so king can't capture.
+	c, err := New(
+		WithFEN("7k/5Q2/6K1/8/8/8/8/8 w - - 0 1"),
+		WithParallelism(1),
+	)
+	require.NoError(t, err)
+
+	fenBefore := c.FEN()
+
+	san, err := c.SAN("f7g7")
+	require.NoError(t, err)
+	assert.Equal(t, "Qg7#", san)
+
+	// The board must be completely unchanged after calling SAN.
+	fenAfter := c.FEN()
+	assert.Equal(t, fenBefore, fenAfter, "SAN() must not mutate the board state")
+
+	// The move must still be legal (board not corrupted).
+	uci, err := c.FromSAN("Qg7")
+	require.NoError(t, err)
+	assert.Equal(t, "f7g7", uci)
+}


### PR DESCRIPTION
Addresses the three actionable Copilot review comments from PR #44:

**1. Error handling (nil panic risk)**
`New(WithFEN(...))` can return an error (e.g., empty or invalid FEN). The previous code discarded it with `_`, leaving `cloned` nil and causing a panic on the next line. Now returns `""` early if `New` fails.

**2. Comment alignment**
The old comment said "Use LoadPosition…" but no `LoadPosition` call exists. Updated to accurately describe what the code does.

**3. Regression test**
Added `TestSAN_DoesNotMutateBoard` — uses a checkmate position (`7k/5Q2/6K1/8/8/8/8/8 w - - 0 1`, Qg7#) so that `checkSuffix` exercises the `New(WithFEN(...))` path and produces a `"#"` suffix, then asserts the board FEN is unchanged before and after the `SAN()` call.

The fourth comment (performance — rebuild vs. fix `clone()`) is acknowledged as a known trade-off; `checkSuffix` is called once per SAN generation so the overhead is acceptable for now.

Releases as **v2.0.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)