### PR TITLE
Update module path to github.com/RchrdHndrcks/gochess/v2

### DIFF
--- a/board_test.go
+++ b/board_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 )
 
 var fenAnalysisRegex = regexp.MustCompile("[/0-9]")

--- a/chess/adapter.go
+++ b/chess/adapter.go
@@ -1,6 +1,6 @@
 package chess
 
-import "github.com/RchrdHndrcks/gochess"
+import "github.com/RchrdHndrcks/gochess/v2"
 
 // boardAdapter is an adapter for gochess.Board that implements the Board interface.
 //

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 )
 
 type (

--- a/chess/chess_benchmark_test.go
+++ b/chess/chess_benchmark_test.go
@@ -3,7 +3,7 @@ package chess_test
 import (
 	"testing"
 
-	"github.com/RchrdHndrcks/gochess/chess"
+	"github.com/RchrdHndrcks/gochess/v2/chess"
 )
 
 func BenchmarkCapablancaSteiner(b *testing.B) {

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/RchrdHndrcks/gochess"
-	"github.com/RchrdHndrcks/gochess/chess"
+	"github.com/RchrdHndrcks/gochess/v2"
+	"github.com/RchrdHndrcks/gochess/v2/chess"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 )
 
 // capacityByPiece is a helper map where the key is the piece and the value is

--- a/chess/notation.go
+++ b/chess/notation.go
@@ -3,7 +3,7 @@ package chess
 import (
 	"fmt"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 )
 
 // AlgebraicToCoordinate returns a new Coordinate from text notation.

--- a/chess/notation_test.go
+++ b/chess/notation_test.go
@@ -3,8 +3,8 @@ package chess_test
 import (
 	"testing"
 
-	"github.com/RchrdHndrcks/gochess"
-	"github.com/RchrdHndrcks/gochess/chess"
+	"github.com/RchrdHndrcks/gochess/v2"
+	"github.com/RchrdHndrcks/gochess/v2/chess"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chess/options_test.go
+++ b/chess/options_test.go
@@ -3,7 +3,7 @@ package chess
 import (
 	"testing"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 )
 
 func TestWithParallelism(t *testing.T) {

--- a/chess/pgn.go
+++ b/chess/pgn.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/RchrdHndrcks/gochess"
-	chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
+	"github.com/RchrdHndrcks/gochess/v2"
+	chesspgn "github.com/RchrdHndrcks/gochess/v2/chess/pgn"
 )
 
 // PGN generates a PGN string from the current game state.

--- a/chess/pgn/pgn_test.go
+++ b/chess/pgn/pgn_test.go
@@ -3,7 +3,7 @@ package pgn_test
 import (
 	"testing"
 
-	chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
+	chesspgn "github.com/RchrdHndrcks/gochess/v2/chess/pgn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chess/pgn_test.go
+++ b/chess/pgn_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/RchrdHndrcks/gochess/chess"
-	chesspgn "github.com/RchrdHndrcks/gochess/chess/pgn"
+	"github.com/RchrdHndrcks/gochess/v2/chess"
+	chesspgn "github.com/RchrdHndrcks/gochess/v2/chess/pgn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/chess/san.go
+++ b/chess/san.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/RchrdHndrcks/gochess"
+	"github.com/RchrdHndrcks/gochess/v2"
 )
 
 // SAN converts a UCI move (like "e2e4") to Standard Algebraic Notation (like "e4").

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RchrdHndrcks/gochess
+module github.com/RchrdHndrcks/gochess/v2
 
 go 1.24.2
 


### PR DESCRIPTION
## Why

The repo is already tagged at v2.x.x but the `go.mod` module declaration still reads `github.com/RchrdHndrcks/gochess`. The Go module proxy rejects `v2.0.x` tags from this module with:

```
invalid version: module contains a go.mod file, so module path must match major version ("github.com/RchrdHndrcks/gochess/v2")
```

This means consumers (including enrok) cannot import the library at any v2 tag without a local `replace` directive.

## What

- `go.mod`: `module github.com/RchrdHndrcks/gochess` → `module github.com/RchrdHndrcks/gochess/v2`
- All internal imports updated to `github.com/RchrdHndrcks/gochess/v2` (root) and `github.com/RchrdHndrcks/gochess/v2/chess/pgn` (subpackage)

## Impact on consumers

After merging, consumers must update their imports from:
```go
import "github.com/RchrdHndrcks/gochess"
```
to:
```go
import "github.com/RchrdHndrcks/gochess/v2"
```

This is a **breaking change** per Go module conventions — it's the correct way to signal a major version bump. The next tag after this merge should be **v2.0.1** (or whatever patch is current), and the existing v2.0.1 tag will need to be moved to point to this commit or a subsequent one.

## Verification

```
ok  github.com/RchrdHndrcks/gochess/v2            0.85s
ok  github.com/RchrdHndrcks/gochess/v2/chess       1.35s
ok  github.com/RchrdHndrcks/gochess/v2/chess/pgn   0.64s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)