### PR TITLE
Add compact Move type and MakeMoveCompact

### DIFF
--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -3,14 +3,11 @@ package chess
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/RchrdHndrcks/gochess/v2"
 )
-
-var fenAnalysisRegex = regexp.MustCompile("[/0-9]")
 
 // loadPosition is a helper function that loads a board from a FEN string.
 //
@@ -299,25 +296,18 @@ func (c *Chess) updateHalfMoves() {
 		return
 	}
 
-	// Look for a change in the board.
-	// If we have less pieces than before, a capture was made so we reset the counter.
-	lastFENPiecePart := strings.Split(h.fen, " ")[0]
-
-	lastFENPiecePart = fenAnalysisRegex.ReplaceAllString(lastFENPiecePart, "")
-	fenPiecePart := fenAnalysisRegex.ReplaceAllString(c.calculateBoardFEN(), "")
-
-	if len(lastFENPiecePart) > len(fenPiecePart) {
+	// If a capture was made, reset.
+	if h.capturedPiece != gochess.Empty {
 		c.halfMoves = 0
 		return
 	}
 
-	// If no capture was made, we check if last move was a pawn move.
+	// If no capture was made, check whether the last move was a pawn move.
 	target := h.move[2:4]
 	coor, _ := AlgebraicToCoordinate(target)
 	p, _ := c.board.Square(coor)
 
-	piece := gochess.PieceType(p)
-	if piece == gochess.Pawn {
+	if gochess.PieceType(p) == gochess.Pawn {
 		c.halfMoves = 0
 	}
 }

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -425,6 +425,7 @@ func (c *Chess) MakeMoveCompact(m Move) error {
 		isEnPassant:   c.isEnPassantMove(uci),
 		promotionType: m.Promotion(),
 		uci:           uci,
+		compact:       m,
 	}
 
 	if md.isEnPassant {
@@ -465,20 +466,35 @@ func (c *Chess) ParseUCIMove(uci string) (Move, error) {
 }
 
 // Moves returns all legal moves for the current position as compact Move
-// values. The GivesCheck bit is computed for each move by playing it,
-// checking whether the opponent is in check, and unmaking it.
+// values. The GivesCheck bit is computed for each move by playing it on the
+// internal board, calling isCheck, and unmaking it. The lightweight
+// applyMove/unmakeMove path is used (no FEN recompute, no legal-move-list
+// refresh) so this stays O(n) over the legal moves.
 func (c *Chess) Moves() []Move {
 	uciMoves := c.moves
 	out := make([]Move, 0, len(uciMoves))
 	for _, uci := range uciMoves {
 		m := c.uciToCompactMove(uci)
-		// Detect gives-check by playing/unmaking the move.
-		if err := c.MakeMoveCompact(m); err == nil {
-			if c.isCheck() {
-				m = m.WithGivesCheck(true)
-			}
-			c.UnmakeMoveCompact()
+		md := moveData{
+			from:          m.From(),
+			to:            m.To(),
+			isCastle:      c.isCastleMove(uci),
+			isEnPassant:   c.isEnPassantMove(uci),
+			promotionType: m.Promotion(),
+			uci:           uci,
+			compact:       m,
 		}
+		if md.isEnPassant {
+			md.capturedPiece = gochess.Pawn | opponentColor(c.turn)
+		} else {
+			dst, _ := c.board.Square(md.to)
+			md.capturedPiece = dst
+		}
+		c.applyMove(md)
+		if c.isCheck() {
+			m = m.WithGivesCheck(true)
+		}
+		c.unmakeMove()
 		out = append(out, m)
 	}
 	return out

--- a/chess/chess.go
+++ b/chess/chess.go
@@ -34,10 +34,20 @@ type (
 
 	// chessContext represents the history of a game.
 	chessContext struct {
-		// move is a played move.
+		// move is the played move in UCI notation. Kept for unmakeMove which
+		// parses the string to recover origin/target/promotion data.
 		move string
-		// fen is a FEN strings that represents the position.
-		fen string
+		// compactMove is the same move in packed form. Set when MakeMoveCompact
+		// is the entry point (NullMove for the legacy makeMove(uci) path, since
+		// the engine uses move for unmake either way).
+		compactMove Move
+		// capturedPiece is the piece captured by this move (Empty if none).
+		// For en passant, this is the captured pawn (with color).
+		capturedPiece gochess.Piece
+		// positionKey is the first three FEN fields (placement / active color /
+		// castling rights) of the position before the move was made. Used for
+		// threefold-repetition detection without re-parsing FEN strings.
+		positionKey string
 		// halfMove is the number of half moves since the last capture or pawn move.
 		halfMove int
 		// availableCastles is the castles that are available.
@@ -345,7 +355,7 @@ func (c *Chess) IsThreefoldRepetition() bool {
 	currentKey := positionKey(c.actualFEN)
 	count := 1 // current position counts as one occurrence
 	for _, ctx := range c.history {
-		if positionKey(ctx.fen) == currentKey {
+		if ctx.positionKey == currentKey {
 			count++
 			if count >= 3 {
 				return true
@@ -386,6 +396,167 @@ func (c *Chess) Square(square string) (string, error) {
 	}
 
 	return gochess.PieceNames[p], nil
+}
+
+// MakeMoveCompact applies the given compact Move to the board.
+//
+// The move is validated against the legal move list (by UCI string) and
+// rejected with an error if it is not legal in the current position. On
+// success, the FEN, legal-move list and check/checkmate/stalemate flags
+// are recomputed.
+//
+// Unlike MakeMove(string), the board mutation does not parse strings:
+// the from/to/flags/promotion are read directly from the Move bits and
+// passed to applyMove. The only string allocated is m.UCI(), which is
+// stored in history because unmakeMove parses it.
+func (c *Chess) MakeMoveCompact(m Move) error {
+	uci := m.UCI()
+	if !slices.Contains(c.moves, uci) {
+		return fmt.Errorf("move is not legal: %s", uci)
+	}
+
+	from := m.From()
+	to := m.To()
+
+	md := moveData{
+		from:          from,
+		to:            to,
+		isCastle:      c.isCastleMove(uci),
+		isEnPassant:   c.isEnPassantMove(uci),
+		promotionType: m.Promotion(),
+		uci:           uci,
+	}
+
+	if md.isEnPassant {
+		md.capturedPiece = gochess.Pawn | opponentColor(c.turn)
+	} else {
+		dst, _ := c.board.Square(to)
+		md.capturedPiece = dst
+	}
+
+	c.applyMove(md)
+	c.actualFEN = c.calculateFEN(uci)
+	c.moves = c.legalMoves()
+	check := c.isCheck()
+	c.check = check && len(c.moves) > 0
+	c.checkmate = check && len(c.moves) == 0
+	c.stalemate = !check && len(c.moves) == 0
+	return nil
+}
+
+// UnmakeMoveCompact unmakes the last move and recomputes the legal-move list.
+func (c *Chess) UnmakeMoveCompact() {
+	c.unmakeMove()
+	c.moves = c.legalMoves()
+}
+
+// ParseUCIMove validates the given UCI string against the current legal
+// move list and, if legal, returns its compact Move representation. The
+// returned Move has from/to/flags/promotion/captured filled in but does
+// not set the GivesCheck bit.
+func (c *Chess) ParseUCIMove(uci string) (Move, error) {
+	if len(uci) != 4 && len(uci) != 5 {
+		return NullMove, fmt.Errorf("invalid UCI move: %q", uci)
+	}
+	if !slices.Contains(c.moves, uci) {
+		return NullMove, fmt.Errorf("move is not legal: %s", uci)
+	}
+	return c.uciToCompactMove(uci), nil
+}
+
+// Moves returns all legal moves for the current position as compact Move
+// values. The GivesCheck bit is computed for each move by playing it,
+// checking whether the opponent is in check, and unmaking it.
+func (c *Chess) Moves() []Move {
+	uciMoves := c.moves
+	out := make([]Move, 0, len(uciMoves))
+	for _, uci := range uciMoves {
+		m := c.uciToCompactMove(uci)
+		// Detect gives-check by playing/unmaking the move.
+		if err := c.MakeMoveCompact(m); err == nil {
+			if c.isCheck() {
+				m = m.WithGivesCheck(true)
+			}
+			c.UnmakeMoveCompact()
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// PieceAt returns the piece type, color, and ok=true if a piece exists at
+// the given 0-63 square index. Returns zero values and ok=false if the
+// square is empty or out of range.
+func (c *Chess) PieceAt(sq int) (pieceType, color gochess.Piece, ok bool) {
+	if sq < 0 || sq >= 64 {
+		return 0, 0, false
+	}
+	coor := coordinateFromSquare(uint32(sq))
+	p, err := c.board.Square(coor)
+	if err != nil || p == gochess.Empty {
+		return 0, 0, false
+	}
+	return gochess.PieceType(p), gochess.PieceColor(p), true
+}
+
+// uciToCompactMove inspects current board state to determine flags,
+// captured piece, and promotion for the given UCI string.
+func (c *Chess) uciToCompactMove(uci string) Move {
+	from, _ := AlgebraicToCoordinate(uci[:2])
+	to, _ := AlgebraicToCoordinate(uci[2:4])
+
+	isCastle := c.isCastleMove(uci)
+	isEP := c.isEnPassantMove(uci)
+
+	var captured gochess.Piece
+	if isEP {
+		captured = gochess.Pawn
+	} else {
+		dst, _ := c.board.Square(to)
+		captured = gochess.PieceType(dst)
+	}
+
+	var promo gochess.Piece
+	if len(uci) == 5 {
+		promo = gochess.PiecesWithoutColor[uci[4:5]]
+	}
+
+	// Detect double pawn push.
+	isDoublePush := false
+	if !isCastle && !isEP && promo == gochess.Empty {
+		fp, _ := c.board.Square(from)
+		if gochess.PieceType(fp) == gochess.Pawn {
+			dy := to.Y - from.Y
+			if dy == 2 || dy == -2 {
+				isDoublePush = true
+			}
+		}
+	}
+
+	flag := FlagQuiet
+	switch {
+	case isCastle:
+		flag = FlagCastle
+	case isEP:
+		flag = FlagEnPassant
+	case promo != gochess.Empty && captured != gochess.Empty:
+		flag = FlagPromotionCapture
+	case promo != gochess.Empty:
+		flag = FlagPromotion
+	case captured != gochess.Empty:
+		flag = FlagCapture
+	case isDoublePush:
+		flag = FlagDoublePush
+	}
+
+	m := NewMove(from, to, flag)
+	if promo != gochess.Empty {
+		m = m.WithPromotion(promo)
+	}
+	if captured != gochess.Empty {
+		m = m.WithCapturedPiece(captured)
+	}
+	return m
 }
 
 // clone creates a deep copy of the Chess structure.

--- a/chess/chess_test.go
+++ b/chess/chess_test.go
@@ -1289,3 +1289,36 @@ func TestEnPassantFENRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestChessContextRefactorRegression(t *testing.T) {
+	// Play a 9-move Ruy Lopez opening, then unmake all moves and verify
+	// that the start position FEN is restored. This exercises the
+	// chessContext refactor (no fen field, capturedPiece + positionKey)
+	// and ensures unmakeMove correctly recomputes FEN via calculateFEN.
+	c, err := chess.New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	startFEN := c.FEN()
+
+	moves := []string{
+		"e2e4", "e7e5",
+		"g1f3", "b8c6",
+		"f1b5", "a7a6",
+		"b5a4", "g8f6",
+		"e1g1", // White castles kingside.
+	}
+	for _, m := range moves {
+		if err := c.MakeMove(m); err != nil {
+			t.Fatalf("MakeMove(%s): %v", m, err)
+		}
+	}
+
+	for range moves {
+		c.UnmakeMove()
+	}
+
+	if got := c.FEN(); got != startFEN {
+		t.Errorf("FEN after unmaking all moves:\n  got:  %s\n  want: %s", got, startFEN)
+	}
+}

--- a/chess/move_compact.go
+++ b/chess/move_compact.go
@@ -1,0 +1,205 @@
+package chess
+
+import (
+	"github.com/RchrdHndrcks/gochess/v2"
+)
+
+// Move is a packed representation of a chess move.
+//
+// Layout (32 bits):
+//
+//	bits  0-5:  from square (0-63)
+//	bits  6-11: to square (0-63)
+//	bits 12-14: promotion piece index (None=0, Knight=1, Bishop=2, Rook=3, Queen=4)
+//	bits 15-17: flags (Quiet, Capture, EnPassant, Castle, DoublePush, Promotion, PromotionCapture)
+//	bits 18-20: captured piece index (Pawn=1, Knight=2, Bishop=3, Rook=4, Queen=5, King=6)
+//	bit  21:    gives check (1 = move delivers check to opponent)
+//	bits 22-31: reserved for future use (e.g., move ordering score)
+type Move uint32
+
+// MoveFlag categorises the kind of move encoded in a Move.
+type MoveFlag uint8
+
+// Move flag values stored in bits 15-17 of Move.
+const (
+	FlagQuiet            MoveFlag = 0
+	FlagCapture          MoveFlag = 1
+	FlagEnPassant        MoveFlag = 2
+	FlagCastle           MoveFlag = 3
+	FlagDoublePush       MoveFlag = 4
+	FlagPromotion        MoveFlag = 5
+	FlagPromotionCapture MoveFlag = 6
+)
+
+// NullMove is the zero Move, used as a sentinel for "no move".
+const NullMove Move = 0
+
+// Bit layout helpers.
+const (
+	moveFromShift      = 0
+	moveToShift        = 6
+	movePromoShift     = 12
+	moveFlagsShift     = 15
+	moveCapturedShift  = 18
+	moveGivesCheckBit  = 21
+	moveSquareMask     = 0x3F
+	movePromoMask      = 0x7
+	moveFlagsMask      = 0x7
+	moveCapturedMask   = 0x7
+	moveGivesCheckMask = uint32(1) << moveGivesCheckBit
+)
+
+// promotionIndex maps a promotion piece type to its 3-bit index in Move.
+var promotionIndex = map[gochess.Piece]uint32{
+	gochess.Empty:  0,
+	gochess.Knight: 1,
+	gochess.Bishop: 2,
+	gochess.Rook:   3,
+	gochess.Queen:  4,
+}
+
+// promotionPiece is the inverse lookup for promotionIndex.
+var promotionPiece = [...]gochess.Piece{
+	0: gochess.Empty,
+	1: gochess.Knight,
+	2: gochess.Bishop,
+	3: gochess.Rook,
+	4: gochess.Queen,
+}
+
+// capturedIndex maps a piece type (without color) to its 3-bit captured index.
+var capturedIndex = map[gochess.Piece]uint32{
+	gochess.Empty:  0,
+	gochess.Pawn:   1,
+	gochess.Knight: 2,
+	gochess.Bishop: 3,
+	gochess.Rook:   4,
+	gochess.Queen:  5,
+	gochess.King:   6,
+}
+
+// capturedPieceFromIndex is the inverse lookup for capturedIndex.
+var capturedPieceFromIndex = [...]gochess.Piece{
+	0: gochess.Empty,
+	1: gochess.Pawn,
+	2: gochess.Knight,
+	3: gochess.Bishop,
+	4: gochess.Rook,
+	5: gochess.Queen,
+	6: gochess.King,
+}
+
+// squareFromCoordinate converts a (X,Y) board coordinate (Y=0 is rank 8) into a
+// 0-63 square index where a1=0 and h8=63.
+func squareFromCoordinate(c gochess.Coordinate) uint32 {
+	return uint32((7-c.Y)*8 + c.X)
+}
+
+// coordinateFromSquare is the inverse of squareFromCoordinate.
+func coordinateFromSquare(sq uint32) gochess.Coordinate {
+	x := int(sq) % 8
+	rank := int(sq) / 8 // 0..7 where 0 is rank 1
+	y := 7 - rank
+	return gochess.Coor(x, y)
+}
+
+// NewMove builds a Move with the given from/to squares and flag, no
+// promotion, no captured piece, no gives-check bit set. Use the With*
+// builder methods to layer additional information.
+func NewMove(from, to gochess.Coordinate, flags MoveFlag) Move {
+	return Move(squareFromCoordinate(from)<<moveFromShift |
+		squareFromCoordinate(to)<<moveToShift |
+		uint32(flags)<<moveFlagsShift)
+}
+
+// From returns the origin coordinate of the move.
+func (m Move) From() gochess.Coordinate {
+	return coordinateFromSquare((uint32(m) >> moveFromShift) & moveSquareMask)
+}
+
+// To returns the destination coordinate of the move.
+func (m Move) To() gochess.Coordinate {
+	return coordinateFromSquare((uint32(m) >> moveToShift) & moveSquareMask)
+}
+
+// Flags returns the move flag.
+func (m Move) Flags() MoveFlag {
+	return MoveFlag((uint32(m) >> moveFlagsShift) & moveFlagsMask)
+}
+
+// Promotion returns the promotion piece type (without color), or
+// gochess.Empty if the move is not a promotion.
+func (m Move) Promotion() gochess.Piece {
+	idx := (uint32(m) >> movePromoShift) & movePromoMask
+	if int(idx) >= len(promotionPiece) {
+		return gochess.Empty
+	}
+	return promotionPiece[idx]
+}
+
+// CapturedPiece returns the captured piece type (without color), or
+// gochess.Empty if the move did not capture.
+func (m Move) CapturedPiece() gochess.Piece {
+	idx := (uint32(m) >> moveCapturedShift) & moveCapturedMask
+	if int(idx) >= len(capturedPieceFromIndex) {
+		return gochess.Empty
+	}
+	return capturedPieceFromIndex[idx]
+}
+
+// IsCapture reports whether the move captures a piece (regular capture,
+// en passant, or promotion-capture).
+func (m Move) IsCapture() bool {
+	f := m.Flags()
+	return f == FlagCapture || f == FlagEnPassant || f == FlagPromotionCapture
+}
+
+// GivesCheck reports whether bit 21 is set indicating the move delivers
+// check to the opponent. Only guaranteed for moves freshly returned by
+// Moves()/Captures()/QuietMoves(); reconstructed moves do not have it set.
+func (m Move) GivesCheck() bool {
+	return uint32(m)&moveGivesCheckMask != 0
+}
+
+// WithPromotion returns a copy of m with the given promotion piece type set.
+// piece must be one of Knight, Bishop, Rook, Queen (color is ignored).
+func (m Move) WithPromotion(piece gochess.Piece) Move {
+	pt := gochess.PieceType(piece)
+	idx, ok := promotionIndex[pt]
+	if !ok {
+		idx = 0
+	}
+	cleared := uint32(m) &^ (movePromoMask << movePromoShift)
+	return Move(cleared | idx<<movePromoShift)
+}
+
+// WithCapturedPiece returns a copy of m with the captured piece type stored.
+// piece is the piece that lived on the destination (or behind it for EP)
+// before the move; color is ignored.
+func (m Move) WithCapturedPiece(piece gochess.Piece) Move {
+	pt := gochess.PieceType(piece)
+	idx, ok := capturedIndex[pt]
+	if !ok {
+		idx = 0
+	}
+	cleared := uint32(m) &^ (moveCapturedMask << moveCapturedShift)
+	return Move(cleared | idx<<moveCapturedShift)
+}
+
+// WithGivesCheck returns a copy of m with bit 21 set or cleared.
+func (m Move) WithGivesCheck(givesCheck bool) Move {
+	if givesCheck {
+		return Move(uint32(m) | moveGivesCheckMask)
+	}
+	return Move(uint32(m) &^ moveGivesCheckMask)
+}
+
+// UCI returns the UCI string representation of the move.
+func (m Move) UCI() string {
+	from := m.From()
+	to := m.To()
+	if promo := m.Promotion(); promo != gochess.Empty {
+		return UCI(from, to, promo)
+	}
+	return UCI(from, to)
+}

--- a/chess/move_compact_test.go
+++ b/chess/move_compact_test.go
@@ -1,0 +1,171 @@
+package chess
+
+import (
+	"testing"
+
+	"github.com/RchrdHndrcks/gochess/v2"
+)
+
+func TestMove_NullMove(t *testing.T) {
+	t.Run("NullMove is zero", func(t *testing.T) {
+		if NullMove != 0 {
+			t.Fatalf("NullMove = %d, want 0", NullMove)
+		}
+	})
+}
+
+func TestMove_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name      string
+		from, to  gochess.Coordinate
+		flag      MoveFlag
+		promo     gochess.Piece
+		captured  gochess.Piece
+		uci       string
+		isCapture bool
+	}{
+		{
+			name: "quiet pawn push e2e4",
+			from: mustAlg(t, "e2"), to: mustAlg(t, "e4"),
+			flag: FlagDoublePush, uci: "e2e4",
+		},
+		{
+			name: "quiet knight g1f3",
+			from: mustAlg(t, "g1"), to: mustAlg(t, "f3"),
+			flag: FlagQuiet, uci: "g1f3",
+		},
+		{
+			name: "capture exd5",
+			from: mustAlg(t, "e4"), to: mustAlg(t, "d5"),
+			flag: FlagCapture, captured: gochess.Pawn,
+			uci: "e4d5", isCapture: true,
+		},
+		{
+			name: "en passant",
+			from: mustAlg(t, "e5"), to: mustAlg(t, "d6"),
+			flag: FlagEnPassant, captured: gochess.Pawn,
+			uci: "e5d6", isCapture: true,
+		},
+		{
+			name: "kingside castle",
+			from: mustAlg(t, "e1"), to: mustAlg(t, "g1"),
+			flag: FlagCastle, uci: "e1g1",
+		},
+		{
+			name: "promotion to queen",
+			from: mustAlg(t, "e7"), to: mustAlg(t, "e8"),
+			flag: FlagPromotion, promo: gochess.Queen,
+			uci: "e7e8q",
+		},
+		{
+			name: "promotion-capture to knight",
+			from: mustAlg(t, "e7"), to: mustAlg(t, "d8"),
+			flag: FlagPromotionCapture, promo: gochess.Knight, captured: gochess.Rook,
+			uci: "e7d8n", isCapture: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMove(tc.from, tc.to, tc.flag)
+			if tc.promo != gochess.Empty {
+				m = m.WithPromotion(tc.promo)
+			}
+			if tc.captured != gochess.Empty {
+				m = m.WithCapturedPiece(tc.captured)
+			}
+
+			if got := m.From(); got != tc.from {
+				t.Errorf("From = %v, want %v", got, tc.from)
+			}
+			if got := m.To(); got != tc.to {
+				t.Errorf("To = %v, want %v", got, tc.to)
+			}
+			if got := m.Flags(); got != tc.flag {
+				t.Errorf("Flags = %d, want %d", got, tc.flag)
+			}
+			if got := m.Promotion(); got != tc.promo {
+				t.Errorf("Promotion = %v, want %v", got, tc.promo)
+			}
+			if got := m.CapturedPiece(); got != tc.captured {
+				t.Errorf("CapturedPiece = %v, want %v", got, tc.captured)
+			}
+			if got := m.IsCapture(); got != tc.isCapture {
+				t.Errorf("IsCapture = %v, want %v", got, tc.isCapture)
+			}
+			if got := m.UCI(); got != tc.uci {
+				t.Errorf("UCI = %q, want %q", got, tc.uci)
+			}
+			if m.GivesCheck() {
+				t.Errorf("GivesCheck = true, want false (not set)")
+			}
+
+			// GivesCheck round-trip.
+			withCheck := m.WithGivesCheck(true)
+			if !withCheck.GivesCheck() {
+				t.Errorf("WithGivesCheck(true).GivesCheck() = false, want true")
+			}
+			// Verify other fields preserved.
+			if withCheck.From() != tc.from || withCheck.To() != tc.to ||
+				withCheck.Flags() != tc.flag || withCheck.Promotion() != tc.promo ||
+				withCheck.CapturedPiece() != tc.captured {
+				t.Errorf("WithGivesCheck mutated other fields")
+			}
+		})
+	}
+}
+
+func TestMove_IsCapture(t *testing.T) {
+	cases := []struct {
+		flag MoveFlag
+		want bool
+	}{
+		{FlagQuiet, false},
+		{FlagDoublePush, false},
+		{FlagCastle, false},
+		{FlagPromotion, false},
+		{FlagCapture, true},
+		{FlagEnPassant, true},
+		{FlagPromotionCapture, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			m := NewMove(mustAlg(t, "a1"), mustAlg(t, "a2"), tc.flag)
+			if got := m.IsCapture(); got != tc.want {
+				t.Errorf("flag %d: IsCapture = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMove_SquareCoordinateRoundTrip(t *testing.T) {
+	t.Run("a1 == 0", func(t *testing.T) {
+		if got := squareFromCoordinate(mustAlg(t, "a1")); got != 0 {
+			t.Errorf("a1 = %d, want 0", got)
+		}
+	})
+	t.Run("h8 == 63", func(t *testing.T) {
+		if got := squareFromCoordinate(mustAlg(t, "h8")); got != 63 {
+			t.Errorf("h8 = %d, want 63", got)
+		}
+	})
+	t.Run("all 64 squares round-trip", func(t *testing.T) {
+		for sq := uint32(0); sq < 64; sq++ {
+			c := coordinateFromSquare(sq)
+			if got := squareFromCoordinate(c); got != sq {
+				t.Errorf("sq %d -> %v -> %d", sq, c, got)
+			}
+		}
+	})
+}
+
+func mustAlg(t *testing.T, s string) gochess.Coordinate {
+	t.Helper()
+	c, err := AlgebraicToCoordinate(s)
+	if err != nil {
+		t.Fatalf("AlgebraicToCoordinate(%q): %v", s, err)
+	}
+	return c
+}

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -29,6 +29,7 @@ type moveData struct {
 	isCastle      bool
 	isEnPassant   bool
 	uci           string // UCI string stored in history for unmakeMove
+	compact       Move   // compact move; NullMove when entry point is the UCI string path
 }
 
 // makeMove makes a move without checking if it is legal.
@@ -85,7 +86,7 @@ func (c *Chess) applyMove(md moveData) {
 		c.history,
 		chessContext{
 			move:              md.uci,
-			compactMove:       NullMove,
+			compactMove:       md.compact,
 			capturedPiece:     md.capturedPiece,
 			positionKey:       positionKey(c.actualFEN),
 			halfMove:          c.halfMoves,

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -18,48 +18,76 @@ var capacityByPiece = map[gochess.Piece]int{
 	gochess.Black | gochess.Bishop: 13,
 }
 
+// moveData holds pre-parsed move information for the internal applyMove
+// method. Both makeMove (UCI string entry point) and MakeMoveCompact build
+// this struct so that the actual board mutation is string-free.
+type moveData struct {
+	from          gochess.Coordinate
+	to            gochess.Coordinate
+	capturedPiece gochess.Piece // piece captured (with color); Empty if none
+	promotionType gochess.Piece // promotion piece type without color; Empty if none
+	isCastle      bool
+	isEnPassant   bool
+	uci           string // UCI string stored in history for unmakeMove
+}
+
 // makeMove makes a move without checking if it is legal.
 func (c *Chess) makeMove(move string) {
-	lastFEN := c.actualFEN
-
-	// Ignore the error because the move should be already validated.
 	o, _ := AlgebraicToCoordinate(move[:2])
 	t, _ := AlgebraicToCoordinate(move[2:4])
 
-	if c.isCastleMove(move) {
-		// If the move is a castle move, we need to move the rook too.
-		//
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
-		c.makeMoveOnBoard(castleRook[move], gochess.Coor((o.X+t.X)/2, o.Y))
+	md := moveData{
+		from:        o,
+		to:          t,
+		isCastle:    c.isCastleMove(move),
+		isEnPassant: c.isEnPassantMove(move),
+		uci:         move,
 	}
 
-	if c.isEnPassantMove(move) {
-		// If the move is an en passant capture, we need to remove the captured pawn.
-		// The captured pawn is behind the target square.
-		//
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
+	if md.isEnPassant {
+		md.capturedPiece = gochess.Pawn | opponentColor(c.turn)
+	} else {
+		dst, _ := c.board.Square(t)
+		md.capturedPiece = dst
+	}
+
+	if len(move) == 5 {
+		md.promotionType = gochess.PiecesWithoutColor[move[4:5]]
+	}
+
+	c.applyMove(md)
+}
+
+// applyMove mutates the board for a pre-parsed move, updates the history,
+// king positions, side-to-move and derived counters. It is shared between
+// makeMove (string entry point) and MakeMoveCompact.
+func (c *Chess) applyMove(md moveData) {
+	o, t := md.from, md.to
+
+	if md.isCastle {
+		// Move the rook for the castle.
+		c.makeMoveOnBoard(castleRook[md.uci], gochess.Coor((o.X+t.X)/2, o.Y))
+	}
+
+	if md.isEnPassant {
+		// Remove the captured pawn, which lives behind the target square.
 		_ = c.board.SetSquare(gochess.Coor(t.X, o.Y), gochess.Empty)
 	}
 
-	// UCI moves only permit 5 characters if the move is a pawn coronation.
-	if len(move) == 5 {
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
-		_ = c.board.SetSquare(t, gochess.PiecesWithoutColor[move[4:5]]|c.turn)
+	if md.promotionType != gochess.Empty {
+		_ = c.board.SetSquare(t, md.promotionType|c.turn)
 		_ = c.board.SetSquare(o, gochess.Empty)
 	} else {
-		// Ignore the error because the coordinates is valid because
-		// the move is already validated.
 		c.makeMoveOnBoard(o, t)
 	}
 
 	c.history = append(
 		c.history,
 		chessContext{
-			move:              move,
-			fen:               lastFEN,
+			move:              md.uci,
+			compactMove:       NullMove,
+			capturedPiece:     md.capturedPiece,
+			positionKey:       positionKey(c.actualFEN),
 			halfMove:          c.halfMoves,
 			availableCastles:  c.availableCastles,
 			enPassantFile:     c.enPassantFile,
@@ -85,6 +113,14 @@ func (c *Chess) makeMove(move string) {
 	c.updateCastlePossibilities()
 	c.updateHalfMoves()
 	c.updateEnPassantSquare()
+}
+
+// opponentColor returns the opposing color piece bit.
+func opponentColor(color gochess.Piece) gochess.Piece {
+	if color == gochess.White {
+		return gochess.Black
+	}
+	return gochess.White
 }
 
 // makeMoveOnBoard is a helper function to make a move on the board.
@@ -115,7 +151,6 @@ func (c *Chess) unmakeMove() {
 	c.enPassantFile = lastContext.enPassantFile
 	c.whiteKingPosition = lastContext.whiteKingPosition
 	c.blackKingPosition = lastContext.blackKingPosition
-	c.actualFEN = lastContext.fen
 	c.check = lastContext.check
 	c.checkmate = lastContext.checkmate
 	c.stalemate = lastContext.stalemate
@@ -127,31 +162,78 @@ func (c *Chess) unmakeMove() {
 	}
 
 	move := lastContext.move
+	// Note: o = original target, t = original origin (variables are swapped
+	// here so that "moving back" reads naturally as o -> t).
 	o, _ := AlgebraicToCoordinate(move[2:4])
 	t, _ := AlgebraicToCoordinate(move[:2])
 
-	// If it was a promotion, restore the captured piece.
 	if len(move) == 5 {
+		// Promotion: restore the pawn on the origin square.
 		_ = c.board.SetSquare(t, gochess.Pawn|c.turn)
+		// Restore whatever lived on the target square: a captured piece for
+		// a promotion-capture, or Empty for a quiet promotion. Without
+		// clearing here, a quiet promotion would leave the promoted piece
+		// on the destination square.
+		if lastContext.capturedPiece != gochess.Empty {
+			_ = c.board.SetSquare(o, lastContext.capturedPiece)
+		} else {
+			_ = c.board.SetSquare(o, gochess.Empty)
+		}
 	} else {
-		// Move the piece back to its original position
+		// Move the piece back to its original square.
 		c.makeMoveOnBoard(o, t)
-	}
-
-	// Check if there was a capture by examining the previous FEN.
-	capturedPiece := pieceFromFEN(lastContext.fen, o)
-	if capturedPiece != gochess.Empty {
-		_ = c.board.SetSquare(o, capturedPiece)
+		// Restore the captured piece on the destination, if any. For en
+		// passant the captured pawn lives on a different square (handled
+		// below), so leave the diagonal destination empty in that case.
+		isEP := isEnPassantMoveByContext(move, lastContext)
+		if lastContext.capturedPiece != gochess.Empty && !isEP {
+			_ = c.board.SetSquare(o, lastContext.capturedPiece)
+		}
 	}
 
 	if c.isCastleMove(move) {
 		c.makeMoveOnBoard(gochess.Coor((o.X+t.X)/2, o.Y), castleRook[move])
 	}
 
-	if c.isEnPassantMove(move) {
-		// Restore the captured pawn.
-		_ = c.board.SetSquare(gochess.Coor(o.X, t.Y), gochess.Pawn|c.turn)
+	if isEnPassantMoveByContext(move, lastContext) {
+		// The captured pawn belongs to the opponent of the side that made
+		// the EP capture. After toggleColor, c.turn IS the side that made
+		// the capture, so the captured pawn color is the opposite.
+		_ = c.board.SetSquare(gochess.Coor(o.X, t.Y), gochess.Pawn|opponentColor(c.turn))
 	}
+
+	c.actualFEN = c.calculateFEN()
+}
+
+// isEnPassantMoveByContext reports whether the just-undone move was an
+// en passant capture. We can't use Chess.isEnPassantMove because the en
+// passant file has already been restored to the pre-move state and the
+// destination square no longer holds the moving pawn (we just moved it
+// back). Instead, we look at the captured piece slot in the history: an
+// EP capture is the only pawn-target move where the captured pawn lives
+// on a different square than the move's destination.
+func isEnPassantMoveByContext(move string, ctx chessContext) bool {
+	if len(move) != 4 {
+		return false
+	}
+	if gochess.PieceType(ctx.capturedPiece) != gochess.Pawn {
+		return false
+	}
+	// The destination file differs from the origin file (diagonal pawn move)
+	// AND the captured piece slot is set, but the target square in the
+	// pre-move position was empty. The cheapest detector: the move is a
+	// pawn diagonal whose target square's pre-move occupant was empty.
+	// We approximate this via the EP file stored in the restored context:
+	// if the destination square equals the EP target, this is EP.
+	if ctx.enPassantFile < 0 {
+		return false
+	}
+	dest, _ := AlgebraicToCoordinate(move[2:4])
+	if int8(dest.X) != ctx.enPassantFile {
+		return false
+	}
+	// EP target rank: y=2 if white captured (target rank 6), y=5 if black.
+	return dest.Y == 2 || dest.Y == 5
 }
 
 // movesForPiece returns the available moves for a piece.

--- a/chess/moves_compact_test.go
+++ b/chess/moves_compact_test.go
@@ -125,23 +125,54 @@ func TestUnmakeMoveCompact_PromotionWithoutCapture(t *testing.T) {
 }
 
 func TestMoves_GivesCheckBit(t *testing.T) {
-	// Position where Qh5+ delivers check from h5 against an exposed king.
-	c, err := New()
-	if err != nil {
-		t.Fatalf("New: %v", err)
+	// For each tested FEN, generate Moves() and assert that the GivesCheck
+	// bit on every returned move agrees with ground truth (play the move,
+	// query the opponent's king square, and call IsAttacked equivalent via
+	// isCheck on the side now to move, which is the opponent we just moved
+	// against).
+	fens := []string{
+		// Starting position (no checks possible).
+		"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+		// White queen on h5 and black king on e8 — Qh5xf7 etc. gives check.
+		"4k3/5p2/8/7Q/8/8/8/4K3 w - - 0 1",
+		// Kiwipete-like middlegame position with multiple checking moves.
+		"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
 	}
-	// White queen on h5, black king on f7 with an open diagonal/file.
-	if err := c.LoadPosition("4k3/5p2/8/7Q/8/8/8/4K3 w - - 0 1"); err != nil {
-		t.Fatalf("LoadPosition: %v", err)
-	}
-	moves := c.Moves()
-	foundCheck := false
-	for _, m := range moves {
-		if m.GivesCheck() {
-			foundCheck = true
-		}
-	}
-	if !foundCheck {
-		t.Errorf("expected at least one move with GivesCheck set")
+	for _, fen := range fens {
+		fen := fen
+		t.Run(fen, func(t *testing.T) {
+			c, err := New()
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if err := c.LoadPosition(fen); err != nil {
+				t.Fatalf("LoadPosition: %v", err)
+			}
+			moves := c.Moves()
+			anyChecked := false
+			for _, m := range moves {
+				// Ground truth: play the move via MakeMoveCompact, then ask
+				// isCheck (which checks whether the side to move — the
+				// opponent of the player who just moved — is in check).
+				clone, err := New()
+				if err != nil {
+					t.Fatalf("New: %v", err)
+				}
+				if err := clone.LoadPosition(fen); err != nil {
+					t.Fatalf("LoadPosition: %v", err)
+				}
+				if err := clone.MakeMoveCompact(m.WithGivesCheck(false)); err != nil {
+					t.Fatalf("MakeMoveCompact(%s): %v", m.UCI(), err)
+				}
+				wantCheck := clone.isCheck()
+				if got := m.GivesCheck(); got != wantCheck {
+					t.Errorf("move %s GivesCheck=%v, want %v", m.UCI(), got, wantCheck)
+				}
+				if wantCheck {
+					anyChecked = true
+				}
+			}
+			_ = anyChecked
+		})
 	}
 }

--- a/chess/moves_compact_test.go
+++ b/chess/moves_compact_test.go
@@ -1,0 +1,147 @@
+package chess
+
+import (
+	"testing"
+)
+
+const kiwipeteFEN = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
+
+func TestMakeMoveCompact_KiwipeteFENMatchesMakeMove(t *testing.T) {
+	a, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := a.LoadPosition(kiwipeteFEN); err != nil {
+		t.Fatalf("LoadPosition: %v", err)
+	}
+
+	b, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := b.LoadPosition(kiwipeteFEN); err != nil {
+		t.Fatalf("LoadPosition: %v", err)
+	}
+
+	for _, uci := range a.AvailableMoves() {
+		uci := uci
+		t.Run(uci, func(t *testing.T) {
+			if err := a.MakeMove(uci); err != nil {
+				t.Fatalf("MakeMove(%s): %v", uci, err)
+			}
+			m, err := b.ParseUCIMove(uci)
+			if err != nil {
+				t.Fatalf("ParseUCIMove(%s): %v", uci, err)
+			}
+			if err := b.MakeMoveCompact(m); err != nil {
+				t.Fatalf("MakeMoveCompact(%s): %v", uci, err)
+			}
+			if a.FEN() != b.FEN() {
+				t.Errorf("FEN mismatch after %s:\n  MakeMove:        %s\n  MakeMoveCompact: %s",
+					uci, a.FEN(), b.FEN())
+			}
+			a.UnmakeMove()
+			b.UnmakeMoveCompact()
+			if a.FEN() != b.FEN() {
+				t.Errorf("FEN mismatch after unmake %s:\n  UnmakeMove:        %s\n  UnmakeMoveCompact: %s",
+					uci, a.FEN(), b.FEN())
+			}
+		})
+	}
+}
+
+func TestParseUCIMove_RoundTrip(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := c.LoadPosition(kiwipeteFEN); err != nil {
+		t.Fatalf("LoadPosition: %v", err)
+	}
+
+	for _, uci := range c.AvailableMoves() {
+		uci := uci
+		t.Run(uci, func(t *testing.T) {
+			m, err := c.ParseUCIMove(uci)
+			if err != nil {
+				t.Fatalf("ParseUCIMove(%s): %v", uci, err)
+			}
+			if got := m.UCI(); got != uci {
+				t.Errorf("Move.UCI() = %q, want %q", got, uci)
+			}
+		})
+	}
+}
+
+func TestParseUCIMove_Invalid(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cases := []string{
+		"",
+		"e2",
+		"e2e4q5",
+		"z9z9",
+		"e7e8q", // not legal from start position
+	}
+	for _, uci := range cases {
+		uci := uci
+		t.Run(uci, func(t *testing.T) {
+			if _, err := c.ParseUCIMove(uci); err == nil {
+				t.Errorf("ParseUCIMove(%q) want error, got nil", uci)
+			}
+		})
+	}
+}
+
+func TestUnmakeMoveCompact_PromotionWithoutCapture(t *testing.T) {
+	// Position with white pawn on e7, ready to push-promote without capturing.
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	const fen = "k7/4P3/8/8/8/8/8/4K3 w - - 0 1"
+	if err := c.LoadPosition(fen); err != nil {
+		t.Fatalf("LoadPosition: %v", err)
+	}
+
+	beforeFEN := c.FEN()
+	m, err := c.ParseUCIMove("e7e8q")
+	if err != nil {
+		t.Fatalf("ParseUCIMove: %v", err)
+	}
+	if err := c.MakeMoveCompact(m); err != nil {
+		t.Fatalf("MakeMoveCompact: %v", err)
+	}
+	c.UnmakeMoveCompact()
+	if c.FEN() != beforeFEN {
+		t.Errorf("FEN after unmake = %q, want %q", c.FEN(), beforeFEN)
+	}
+	// e8 must be empty.
+	if name, _ := c.Square("e8"); name != "" {
+		t.Errorf("e8 = %q, want empty", name)
+	}
+}
+
+func TestMoves_GivesCheckBit(t *testing.T) {
+	// Position where Qh5+ delivers check from h5 against an exposed king.
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// White queen on h5, black king on f7 with an open diagonal/file.
+	if err := c.LoadPosition("4k3/5p2/8/7Q/8/8/8/4K3 w - - 0 1"); err != nil {
+		t.Fatalf("LoadPosition: %v", err)
+	}
+	moves := c.Moves()
+	foundCheck := false
+	for _, m := range moves {
+		if m.GivesCheck() {
+			foundCheck = true
+		}
+	}
+	if !foundCheck {
+		t.Errorf("expected at least one move with GivesCheck set")
+	}
+}


### PR DESCRIPTION
## Summary
- Add packed `Move uint32` type with bit-encoded fields (from/to/flags/promotion/captured/gives-check)
- Add `MakeMoveCompact`/`UnmakeMoveCompact` that operate on bits, not strings
- Add `ParseUCIMove`, `Moves()`, `PieceAt()` public methods
- Optimize `chessContext` to store captured piece directly (drop FEN storage), with `positionKey` for repetition detection
- Fix unmake of promotion-without-capture to clear destination square
- `applyMove` extracted from `makeMove` so both UCI-string and compact-move paths share the same string-free board mutation

Part 2 of 7 stacked PRs decomposing #47.

## Test plan
- [x] MakeMoveCompact produces same FEN as MakeMove for all Kiwipete moves
- [x] UnmakeMoveCompact restores FEN for all Kiwipete moves
- [x] ParseUCIMove round-trip for all legal moves; rejects invalid/illegal strings
- [x] Promotion unmake without capture regression test
- [x] 9-move Ruy Lopez make/unmake regression for chessContext refactor
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)