### PR TITLE
Add incrementally-maintained piece lists

### DIFF
--- a/chess/chess.go
+++ b/chess/chess.go
@@ -104,6 +104,10 @@ type (
 
 		// history is the history of the game.
 		history []chessContext
+
+		// pieceLists tracks piece locations per color and type.
+		// First index: 0=White, 1=Black. Second index: piece type (1–6).
+		pieceLists [2][7]pieceList
 	}
 )
 
@@ -174,6 +178,8 @@ func New(opts ...Option) (*Chess, error) {
 		}
 	}
 
+	c.initPieceLists()
+
 	return c, nil
 }
 
@@ -189,6 +195,7 @@ func (c *Chess) LoadPosition(FEN string) error {
 	}
 
 	c.actualFEN = FEN
+	c.initPieceLists()
 	c.moves = c.legalMoves()
 	check := c.isCheck()
 	c.check = check && len(c.moves) > 0

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -64,6 +64,13 @@ func (c *Chess) makeMove(move string) {
 func (c *Chess) applyMove(md moveData) {
 	o, t := md.from, md.to
 
+	// Capture the moving piece's type before mutating the board so that
+	// the incremental piece-list updates below can reference it.
+	movingPiece, _ := c.board.Square(o)
+	movingType := gochess.PieceType(movingPiece)
+	moverColor := c.turn
+	oppColor := opponentColor(moverColor)
+
 	if md.isCastle {
 		// Move the rook for the castle.
 		c.makeMoveOnBoard(castleRook[md.uci], gochess.Coor((o.X+t.X)/2, o.Y))
@@ -79,6 +86,30 @@ func (c *Chess) applyMove(md moveData) {
 		_ = c.board.SetSquare(o, gochess.Empty)
 	} else {
 		c.makeMoveOnBoard(o, t)
+	}
+
+	// Incremental piece-list updates. These mirror the board mutations
+	// above and avoid the cost of rescanning the board on every move.
+	switch {
+	case md.isCastle:
+		c.pieceLists[colorIndex(moverColor)][gochess.King].move(o, t)
+		rookFrom := castleRook[md.uci]
+		rookTo := gochess.Coor((o.X+t.X)/2, o.Y)
+		c.pieceLists[colorIndex(moverColor)][gochess.Rook].move(rookFrom, rookTo)
+	case md.isEnPassant:
+		c.pieceLists[colorIndex(moverColor)][gochess.Pawn].move(o, t)
+		c.pieceLists[colorIndex(oppColor)][gochess.Pawn].remove(gochess.Coor(t.X, o.Y))
+	case md.promotionType != gochess.Empty:
+		c.pieceLists[colorIndex(moverColor)][gochess.Pawn].remove(o)
+		if md.capturedPiece != gochess.Empty {
+			c.pieceLists[colorIndex(oppColor)][gochess.PieceType(md.capturedPiece)].remove(t)
+		}
+		c.pieceLists[colorIndex(moverColor)][md.promotionType].add(t)
+	default:
+		if md.capturedPiece != gochess.Empty {
+			c.pieceLists[colorIndex(oppColor)][gochess.PieceType(md.capturedPiece)].remove(t)
+		}
+		c.pieceLists[colorIndex(moverColor)][movingType].move(o, t)
 	}
 
 	c.history = append(
@@ -200,6 +231,40 @@ func (c *Chess) unmakeMove() {
 		// the EP capture. After toggleColor, c.turn IS the side that made
 		// the capture, so the captured pawn color is the opposite.
 		_ = c.board.SetSquare(gochess.Coor(o.X, t.Y), gochess.Pawn|opponentColor(c.turn))
+	}
+
+	// Incremental piece-list updates: reverse the operations performed by
+	// applyMove. c.turn is now the side that made the move (post toggle).
+	moverColor := c.turn
+	oppColor := opponentColor(moverColor)
+	isEP := isEnPassantMoveByContext(move, lastContext)
+	isCastle := c.isCastleMove(move)
+	switch {
+	case isCastle:
+		rookFrom := castleRook[move]
+		rookTo := gochess.Coor((o.X+t.X)/2, o.Y)
+		c.pieceLists[colorIndex(moverColor)][gochess.Rook].move(rookTo, rookFrom)
+		c.pieceLists[colorIndex(moverColor)][gochess.King].move(o, t)
+	case isEP:
+		c.pieceLists[colorIndex(oppColor)][gochess.Pawn].add(gochess.Coor(o.X, t.Y))
+		c.pieceLists[colorIndex(moverColor)][gochess.Pawn].move(o, t)
+	case len(move) == 5:
+		// Promotion (with or without capture).
+		promoType := gochess.PiecesWithoutColor[move[4:5]]
+		c.pieceLists[colorIndex(moverColor)][promoType].remove(o)
+		if lastContext.capturedPiece != gochess.Empty {
+			c.pieceLists[colorIndex(oppColor)][gochess.PieceType(lastContext.capturedPiece)].add(o)
+		}
+		c.pieceLists[colorIndex(moverColor)][gochess.Pawn].add(t)
+	default:
+		// Regular move (possibly capture). Determine moving type from board:
+		// after the board restore, the piece is back on its origin square (t).
+		movedPiece, _ := c.board.Square(t)
+		movedType := gochess.PieceType(movedPiece)
+		c.pieceLists[colorIndex(moverColor)][movedType].move(o, t)
+		if lastContext.capturedPiece != gochess.Empty {
+			c.pieceLists[colorIndex(oppColor)][gochess.PieceType(lastContext.capturedPiece)].add(o)
+		}
 	}
 
 	c.actualFEN = c.calculateFEN()

--- a/chess/piecelist.go
+++ b/chess/piecelist.go
@@ -8,9 +8,13 @@ type pieceList struct {
 	count   int
 }
 
+// add appends sq to the piece list. It panics if the list is already full,
+// since exceeding the per-piece capacity indicates a malformed position
+// (e.g. a FEN with more than 10 pieces of one type) and silently dropping
+// the entry would desynchronize the piece lists from the board.
 func (pl *pieceList) add(sq gochess.Coordinate) {
 	if pl.count >= len(pl.squares) {
-		return
+		panic("chess: pieceList overflow (more pieces of one type than the board supports)")
 	}
 	pl.squares[pl.count] = sq
 	pl.count++
@@ -41,12 +45,18 @@ func (pl *pieceList) slice() []gochess.Coordinate {
 	return result
 }
 
-// colorIndex maps gochess.White → 0, gochess.Black → 1.
+// colorIndex maps gochess.White → 0, gochess.Black → 1. It panics for
+// any other input (gochess.Empty or invalid bit patterns) so that callers
+// cannot silently treat an invalid color as Black.
 func colorIndex(c gochess.Piece) int {
-	if c == gochess.White {
+	switch c {
+	case gochess.White:
 		return 0
+	case gochess.Black:
+		return 1
+	default:
+		panic("chess: invalid piece color passed to colorIndex")
 	}
-	return 1
 }
 
 // initPieceLists resets and repopulates all piece lists from the current board.
@@ -71,7 +81,15 @@ func (c *Chess) initPieceLists() {
 	}
 }
 
-// PieceSquares returns all squares occupied by pieces of the given color and type.
+// PieceSquares returns all squares occupied by pieces of the given color and
+// type. It normalizes pieceType so callers may pass either the bare piece
+// type (e.g. gochess.Pawn) or a colored piece (e.g. gochess.White|gochess.Pawn);
+// it panics if pieceType does not name a real piece type (1..6) so an out-of-
+// range index cannot silently corrupt the result.
 func (c *Chess) PieceSquares(color, pieceType gochess.Piece) []gochess.Coordinate {
-	return c.pieceLists[colorIndex(color)][pieceType].slice()
+	pt := gochess.PieceType(pieceType)
+	if pt < gochess.Pawn || pt > gochess.King {
+		panic("chess: PieceSquares called with invalid piece type")
+	}
+	return c.pieceLists[colorIndex(color)][pt].slice()
 }

--- a/chess/piecelist.go
+++ b/chess/piecelist.go
@@ -1,0 +1,77 @@
+package chess
+
+import "github.com/RchrdHndrcks/gochess/v2"
+
+// pieceList tracks up to 10 squares of a given piece type and color.
+type pieceList struct {
+	squares [10]gochess.Coordinate
+	count   int
+}
+
+func (pl *pieceList) add(sq gochess.Coordinate) {
+	if pl.count >= len(pl.squares) {
+		return
+	}
+	pl.squares[pl.count] = sq
+	pl.count++
+}
+
+func (pl *pieceList) remove(sq gochess.Coordinate) {
+	for i := 0; i < pl.count; i++ {
+		if pl.squares[i] == sq {
+			pl.count--
+			pl.squares[i] = pl.squares[pl.count]
+			return
+		}
+	}
+}
+
+func (pl *pieceList) move(from, to gochess.Coordinate) {
+	for i := 0; i < pl.count; i++ {
+		if pl.squares[i] == from {
+			pl.squares[i] = to
+			return
+		}
+	}
+}
+
+func (pl *pieceList) slice() []gochess.Coordinate {
+	result := make([]gochess.Coordinate, pl.count)
+	copy(result, pl.squares[:pl.count])
+	return result
+}
+
+// colorIndex maps gochess.White → 0, gochess.Black → 1.
+func colorIndex(c gochess.Piece) int {
+	if c == gochess.White {
+		return 0
+	}
+	return 1
+}
+
+// initPieceLists resets and repopulates all piece lists from the current board.
+// Called once during construction (New/LoadPosition), NOT on every move.
+func (c *Chess) initPieceLists() {
+	for i := range c.pieceLists {
+		for j := range c.pieceLists[i] {
+			c.pieceLists[i][j].count = 0
+		}
+	}
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			sq := gochess.Coor(x, y)
+			piece, _ := c.board.Square(sq)
+			if piece == gochess.Empty {
+				continue
+			}
+			color := gochess.PieceColor(piece)
+			ptype := gochess.PieceType(piece)
+			c.pieceLists[colorIndex(color)][ptype].add(sq)
+		}
+	}
+}
+
+// PieceSquares returns all squares occupied by pieces of the given color and type.
+func (c *Chess) PieceSquares(color, pieceType gochess.Piece) []gochess.Coordinate {
+	return c.pieceLists[colorIndex(color)][pieceType].slice()
+}

--- a/chess/piecelist_test.go
+++ b/chess/piecelist_test.go
@@ -1,0 +1,149 @@
+package chess
+
+import (
+	"testing"
+
+	"github.com/RchrdHndrcks/gochess/v2"
+)
+
+// scanBoardPieces returns a [2][7][]gochess.Coordinate of all piece squares
+// found on the board by direct scan, suitable for comparison against the
+// incrementally-maintained piece lists.
+func scanBoardPieces(c *Chess) [2][7]map[gochess.Coordinate]struct{} {
+	var out [2][7]map[gochess.Coordinate]struct{}
+	for i := range out {
+		for j := range out[i] {
+			out[i][j] = make(map[gochess.Coordinate]struct{})
+		}
+	}
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			sq := gochess.Coor(x, y)
+			p, _ := c.board.Square(sq)
+			if p == gochess.Empty {
+				continue
+			}
+			out[colorIndex(gochess.PieceColor(p))][gochess.PieceType(p)][sq] = struct{}{}
+		}
+	}
+	return out
+}
+
+func pieceListsMatchBoard(t *testing.T, c *Chess) {
+	t.Helper()
+	want := scanBoardPieces(c)
+	for ci := 0; ci < 2; ci++ {
+		for pt := 1; pt <= 6; pt++ {
+			got := c.pieceLists[ci][pt].slice()
+			if len(got) != len(want[ci][pt]) {
+				t.Errorf("color=%d type=%d count mismatch: got %d, want %d", ci, pt, len(got), len(want[ci][pt]))
+				continue
+			}
+			for _, sq := range got {
+				if _, ok := want[ci][pt][sq]; !ok {
+					t.Errorf("color=%d type=%d unexpected square %v", ci, pt, sq)
+				}
+			}
+		}
+	}
+}
+
+func TestPieceLists_StartPositionCounts(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	cases := []struct {
+		color gochess.Piece
+		ptype gochess.Piece
+		want  int
+	}{
+		{gochess.White, gochess.Pawn, 8},
+		{gochess.White, gochess.Knight, 2},
+		{gochess.White, gochess.Bishop, 2},
+		{gochess.White, gochess.Rook, 2},
+		{gochess.White, gochess.Queen, 1},
+		{gochess.White, gochess.King, 1},
+		{gochess.Black, gochess.Pawn, 8},
+		{gochess.Black, gochess.Knight, 2},
+		{gochess.Black, gochess.Bishop, 2},
+		{gochess.Black, gochess.Rook, 2},
+		{gochess.Black, gochess.Queen, 1},
+		{gochess.Black, gochess.King, 1},
+	}
+	for _, tc := range cases {
+		got := c.PieceSquares(tc.color, tc.ptype)
+		if len(got) != tc.want {
+			t.Errorf("PieceSquares(%v,%v) = %d, want %d", tc.color, tc.ptype, len(got), tc.want)
+		}
+	}
+}
+
+func TestPieceLists_MatchBoardForVariousPositions(t *testing.T) {
+	fens := []string{
+		"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+		"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+		"8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+		"r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+	}
+	for _, fen := range fens {
+		c, err := New()
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := c.LoadPosition(fen); err != nil {
+			t.Fatalf("LoadPosition(%q): %v", fen, err)
+		}
+		pieceListsMatchBoard(t, c)
+	}
+}
+
+func TestPieceLists_MakeUnmakeStability_Kiwipete(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := c.LoadPosition(kiwipeteFEN); err != nil {
+		t.Fatalf("LoadPosition: %v", err)
+	}
+
+	moves := c.AvailableMoves()
+	for _, mv := range moves {
+		before := scanBoardPieces(c)
+		if err := c.MakeMove(mv); err != nil {
+			t.Fatalf("MakeMove(%s): %v", mv, err)
+		}
+		// After make, piece lists must still match the board.
+		pieceListsMatchBoard(t, c)
+		c.UnmakeMove()
+		// After unmake, piece lists must match the original board state.
+		after := scanBoardPieces(c)
+		for ci := 0; ci < 2; ci++ {
+			for pt := 1; pt <= 6; pt++ {
+				if len(before[ci][pt]) != len(after[ci][pt]) {
+					t.Fatalf("move=%s color=%d type=%d: count changed across make/unmake", mv, ci, pt)
+				}
+			}
+		}
+		pieceListsMatchBoard(t, c)
+	}
+}
+
+func TestPieceLists_PieceSquaresIsIndependent(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := c.PieceSquares(gochess.White, gochess.Pawn)
+	if len(got) != 8 {
+		t.Fatalf("expected 8 white pawns, got %d", len(got))
+	}
+	// Mutate the returned slice; internal state must not change.
+	got[0] = gochess.Coor(0, 0)
+	again := c.PieceSquares(gochess.White, gochess.Pawn)
+	if again[0] == got[0] && got[0] == (gochess.Coordinate{X: 0, Y: 0}) {
+		// only fails if internal state was actually shared
+		t.Fatalf("PieceSquares returned slice that shares internal state")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds per-color, per-type piece lists tracked on a fixed [2][7]pieceList array
- Maintains the lists incrementally inside applyMove/unmakeMove (no full board rescans on each move)
- Adds a bounds check in pieceList.add to guard against malformed positions

Part 3 of 7 in the gochess PR #47 decomposition. Stacked on engine/compact-move.

## Test plan
- [x] go test -count=1 ./... passes
- [x] New TestPieceLists_StartPositionCounts verifies starting counts
- [x] TestPieceLists_MatchBoardForVariousPositions cross-checks lists vs board scan for several FENs
- [x] TestPieceLists_MakeUnmakeStability_Kiwipete iterates every legal move from the Kiwipete position, asserting list/board agreement after make and after unmake
- [x] TestPieceLists_PieceSquaresIsIndependent ensures returned slice does not alias internal storage