### PR TITLE
Add attack maps and optimized check detection

### DIFF
--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -417,17 +417,19 @@ func (c *Chess) toggleColor() {
 
 // isCheck is the helper function that checks if the current turn is in check.
 func (c Chess) isCheck() bool {
+	if c.turn == gochess.Empty {
+		return false
+	}
 	if c.blackKingPosition == nil || c.whiteKingPosition == nil {
 		return false
 	}
 
 	kingPosition := c.kingsPosition(c.turn)
-
-	c.toggleColor()
-	defer c.toggleColor()
-	moves := c.availableMoves()
-
-	return destinationMatch(moves, kingPosition)
+	opponent := gochess.Black
+	if c.turn == gochess.Black {
+		opponent = gochess.White
+	}
+	return c.IsAttacked(kingPosition, opponent)
 }
 
 // kingsPosition returns the position of the king of the given color.

--- a/chess/FEN.go
+++ b/chess/FEN.go
@@ -417,19 +417,12 @@ func (c *Chess) toggleColor() {
 
 // isCheck is the helper function that checks if the current turn is in check.
 func (c Chess) isCheck() bool {
-	if c.turn == gochess.Empty {
-		return false
-	}
 	if c.blackKingPosition == nil || c.whiteKingPosition == nil {
 		return false
 	}
 
 	kingPosition := c.kingsPosition(c.turn)
-	opponent := gochess.Black
-	if c.turn == gochess.Black {
-		opponent = gochess.White
-	}
-	return c.IsAttacked(kingPosition, opponent)
+	return c.IsAttacked(kingPosition, opponentColor(c.turn))
 }
 
 // kingsPosition returns the position of the king of the given color.

--- a/chess/attacks.go
+++ b/chess/attacks.go
@@ -1,0 +1,403 @@
+package chess
+
+import (
+	"strings"
+
+	"github.com/RchrdHndrcks/gochess/v2"
+)
+
+// PieceSet is a bitmask of piece types. Each bit represents one piece type
+// and is used to describe which kinds of pieces attack a given square.
+type PieceSet uint8
+
+// Piece type bits used by PieceSet.
+const (
+	// NoPieces is the empty PieceSet (no piece types present).
+	NoPieces PieceSet = 0
+	// PawnSet is the bit representing pawns.
+	PawnSet PieceSet = 1 << iota
+	// KnightSet is the bit representing knights.
+	KnightSet
+	// BishopSet is the bit representing bishops.
+	BishopSet
+	// RookSet is the bit representing rooks.
+	RookSet
+	// QueenSet is the bit representing queens.
+	QueenSet
+	// KingSet is the bit representing kings.
+	KingSet
+)
+
+// Has reports whether ps contains all bits of p.
+func (ps PieceSet) Has(p PieceSet) bool { return ps&p == p && p != 0 }
+
+// String returns a human-readable representation of the PieceSet for debugging.
+func (ps PieceSet) String() string {
+	if ps == NoPieces {
+		return "NoPieces"
+	}
+	parts := make([]string, 0, 6)
+	if ps&PawnSet != 0 {
+		parts = append(parts, "Pawn")
+	}
+	if ps&KnightSet != 0 {
+		parts = append(parts, "Knight")
+	}
+	if ps&BishopSet != 0 {
+		parts = append(parts, "Bishop")
+	}
+	if ps&RookSet != 0 {
+		parts = append(parts, "Rook")
+	}
+	if ps&QueenSet != 0 {
+		parts = append(parts, "Queen")
+	}
+	if ps&KingSet != 0 {
+		parts = append(parts, "King")
+	}
+	return strings.Join(parts, "|")
+}
+
+// straightDirs are the four orthogonal ray directions (rook/queen).
+var straightDirs = [4][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+
+// diagonalDirs are the four diagonal ray directions (bishop/queen).
+var diagonalDirs = [4][2]int{{1, 1}, {1, -1}, {-1, 1}, {-1, -1}}
+
+// knightOffsets are the eight knight jump offsets.
+var knightOffsets = [8][2]int{
+	{1, 2}, {2, 1}, {-1, 2}, {-2, 1},
+	{1, -2}, {2, -1}, {-1, -2}, {-2, -1},
+}
+
+// kingOffsets are the eight king step offsets.
+var kingOffsets = [8][2]int{
+	{1, 0}, {-1, 0}, {0, 1}, {0, -1},
+	{1, 1}, {1, -1}, {-1, 1}, {-1, -1},
+}
+
+// pawnAttackerOffsets returns the two relative offsets that a pawn of `side`
+// must occupy in order to attack a square. White pawns move toward y=0, so a
+// white pawn attacking square (x,y) sits at (x±1, y+1). Black pawns are mirrored.
+func pawnAttackerOffsets(side gochess.Piece) [2][2]int {
+	if side == gochess.White {
+		return [2][2]int{{-1, 1}, {1, 1}}
+	}
+	return [2][2]int{{-1, -1}, {1, -1}}
+}
+
+// inBounds reports whether (x,y) lies on the 8x8 board.
+func inBounds(x, y int) bool {
+	return x >= 0 && x < 8 && y >= 0 && y < 8
+}
+
+// IsAttacked reports whether the given square is attacked by any piece of
+// the given side. It performs targeted ray, knight and pawn lookups from
+// sq outward and is recomputed on every call (no cache).
+func (c *Chess) IsAttacked(sq gochess.Coordinate, side gochess.Piece) bool {
+	// Pawn attacks.
+	for _, off := range pawnAttackerOffsets(side) {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.Pawn|side {
+			return true
+		}
+	}
+
+	// Knight attacks.
+	for _, off := range knightOffsets {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.Knight|side {
+			return true
+		}
+	}
+
+	// King attacks.
+	for _, off := range kingOffsets {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.King|side {
+			return true
+		}
+	}
+
+	// Straight rays (rook/queen).
+	for _, dir := range straightDirs {
+		for i := 1; i < 8; i++ {
+			x, y := sq.X+dir[0]*i, sq.Y+dir[1]*i
+			if !inBounds(x, y) {
+				break
+			}
+			p, _ := c.board.Square(gochess.Coor(x, y))
+			if p == gochess.Empty {
+				continue
+			}
+			if gochess.PieceColor(p) == side {
+				pt := gochess.PieceType(p)
+				if pt == gochess.Rook || pt == gochess.Queen {
+					return true
+				}
+			}
+			break
+		}
+	}
+
+	// Diagonal rays (bishop/queen).
+	for _, dir := range diagonalDirs {
+		for i := 1; i < 8; i++ {
+			x, y := sq.X+dir[0]*i, sq.Y+dir[1]*i
+			if !inBounds(x, y) {
+				break
+			}
+			p, _ := c.board.Square(gochess.Coor(x, y))
+			if p == gochess.Empty {
+				continue
+			}
+			if gochess.PieceColor(p) == side {
+				pt := gochess.PieceType(p)
+				if pt == gochess.Bishop || pt == gochess.Queen {
+					return true
+				}
+			}
+			break
+		}
+	}
+
+	return false
+}
+
+// AttackedBy returns the set of piece types of the given side that attack sq.
+// It performs targeted lookups outward from sq and is recomputed on every
+// call (no cache).
+func (c *Chess) AttackedBy(sq gochess.Coordinate, side gochess.Piece) PieceSet {
+	var ps PieceSet
+
+	for _, off := range pawnAttackerOffsets(side) {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.Pawn|side {
+			ps |= PawnSet
+			break
+		}
+	}
+
+	for _, off := range knightOffsets {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.Knight|side {
+			ps |= KnightSet
+			break
+		}
+	}
+
+	for _, off := range kingOffsets {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.King|side {
+			ps |= KingSet
+			break
+		}
+	}
+
+	for _, dir := range straightDirs {
+		for i := 1; i < 8; i++ {
+			x, y := sq.X+dir[0]*i, sq.Y+dir[1]*i
+			if !inBounds(x, y) {
+				break
+			}
+			p, _ := c.board.Square(gochess.Coor(x, y))
+			if p == gochess.Empty {
+				continue
+			}
+			if gochess.PieceColor(p) == side {
+				pt := gochess.PieceType(p)
+				if pt == gochess.Rook {
+					ps |= RookSet
+				} else if pt == gochess.Queen {
+					ps |= QueenSet
+				}
+			}
+			break
+		}
+	}
+
+	for _, dir := range diagonalDirs {
+		for i := 1; i < 8; i++ {
+			x, y := sq.X+dir[0]*i, sq.Y+dir[1]*i
+			if !inBounds(x, y) {
+				break
+			}
+			p, _ := c.board.Square(gochess.Coor(x, y))
+			if p == gochess.Empty {
+				continue
+			}
+			if gochess.PieceColor(p) == side {
+				pt := gochess.PieceType(p)
+				if pt == gochess.Bishop {
+					ps |= BishopSet
+				} else if pt == gochess.Queen {
+					ps |= QueenSet
+				}
+			}
+			break
+		}
+	}
+
+	return ps
+}
+
+// PawnAttackMap returns a 64-bit bitmap of every square attacked by at least
+// one pawn of the given side. Bit (y*8 + x) is set when square (x,y) is
+// attacked. Returned as uint64 to avoid heap allocations in hot paths.
+func (c *Chess) PawnAttackMap(side gochess.Piece) uint64 {
+	var bb uint64
+	pawns := c.pieceLists[colorIndex(side)][gochess.Pawn]
+	dy := -1
+	if side == gochess.Black {
+		dy = 1
+	}
+	for i := 0; i < pawns.count; i++ {
+		sq := pawns.squares[i]
+		ty := sq.Y + dy
+		if ty < 0 || ty > 7 {
+			continue
+		}
+		if sq.X-1 >= 0 {
+			bb |= uint64(1) << uint(ty*8+(sq.X-1))
+		}
+		if sq.X+1 <= 7 {
+			bb |= uint64(1) << uint(ty*8+(sq.X+1))
+		}
+	}
+	return bb
+}
+
+// Attackers returns the squares of every piece of the given side that attacks
+// sq, including x-ray attackers along sliding rays (a same-side rook/queen
+// behind another rook/queen on a straight ray, or a same-side bishop/queen
+// behind another bishop/queen on a diagonal ray, is included).
+//
+// Results are appended to dst in cheapest-first order: pawns, knights,
+// bishops, rooks, queens, king. Within the same piece type the order is
+// undefined.
+func (c *Chess) Attackers(sq gochess.Coordinate, side gochess.Piece, dst []gochess.Coordinate) []gochess.Coordinate {
+	var pawns, knights, bishops, rooks, queens, kings []gochess.Coordinate
+
+	// Pawns attacking sq.
+	for _, off := range pawnAttackerOffsets(side) {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.Pawn|side {
+			pawns = append(pawns, gochess.Coor(x, y))
+		}
+	}
+
+	// Knights.
+	for _, off := range knightOffsets {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.Knight|side {
+			knights = append(knights, gochess.Coor(x, y))
+		}
+	}
+
+	// King.
+	for _, off := range kingOffsets {
+		x, y := sq.X+off[0], sq.Y+off[1]
+		if !inBounds(x, y) {
+			continue
+		}
+		p, _ := c.board.Square(gochess.Coor(x, y))
+		if p == gochess.King|side {
+			kings = append(kings, gochess.Coor(x, y))
+		}
+	}
+
+	// Straight rays: x-ray through any same-side rook or queen.
+	for _, dir := range straightDirs {
+		for i := 1; i < 8; i++ {
+			x, y := sq.X+dir[0]*i, sq.Y+dir[1]*i
+			if !inBounds(x, y) {
+				break
+			}
+			p, _ := c.board.Square(gochess.Coor(x, y))
+			if p == gochess.Empty {
+				continue
+			}
+			if gochess.PieceColor(p) != side {
+				break
+			}
+			pt := gochess.PieceType(p)
+			if pt == gochess.Rook {
+				rooks = append(rooks, gochess.Coor(x, y))
+				continue
+			}
+			if pt == gochess.Queen {
+				queens = append(queens, gochess.Coor(x, y))
+				continue
+			}
+			break
+		}
+	}
+
+	// Diagonal rays: x-ray through any same-side bishop or queen.
+	for _, dir := range diagonalDirs {
+		for i := 1; i < 8; i++ {
+			x, y := sq.X+dir[0]*i, sq.Y+dir[1]*i
+			if !inBounds(x, y) {
+				break
+			}
+			p, _ := c.board.Square(gochess.Coor(x, y))
+			if p == gochess.Empty {
+				continue
+			}
+			if gochess.PieceColor(p) != side {
+				break
+			}
+			pt := gochess.PieceType(p)
+			if pt == gochess.Bishop {
+				bishops = append(bishops, gochess.Coor(x, y))
+				continue
+			}
+			if pt == gochess.Queen {
+				queens = append(queens, gochess.Coor(x, y))
+				continue
+			}
+			break
+		}
+	}
+
+	dst = append(dst, pawns...)
+	dst = append(dst, knights...)
+	dst = append(dst, bishops...)
+	dst = append(dst, rooks...)
+	dst = append(dst, queens...)
+	dst = append(dst, kings...)
+	return dst
+}
+

--- a/chess/attacks_test.go
+++ b/chess/attacks_test.go
@@ -1,0 +1,280 @@
+package chess
+
+import (
+	"testing"
+
+	"github.com/RchrdHndrcks/gochess/v2"
+)
+
+func mustNew(t *testing.T, fen string) *Chess {
+	t.Helper()
+	var c *Chess
+	var err error
+	if fen == "" {
+		c, err = New()
+	} else {
+		c, err = New(WithFEN(fen))
+	}
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func sq(t *testing.T, alg string) gochess.Coordinate {
+	t.Helper()
+	co, err := AlgebraicToCoordinate(alg)
+	if err != nil {
+		t.Fatalf("AlgebraicToCoordinate(%q): %v", alg, err)
+	}
+	return co
+}
+
+func TestIsAttacked(t *testing.T) {
+	t.Run("start position pawn attacks", func(t *testing.T) {
+		c := mustNew(t, "")
+		// White pawns on rank 2 attack rank 3.
+		for _, s := range []string{"a3", "b3", "c3", "d3", "e3", "f3", "g3", "h3"} {
+			if !c.IsAttacked(sq(t, s), gochess.White) {
+				t.Errorf("expected %s attacked by white", s)
+			}
+		}
+		// Black pawns on rank 7 attack rank 6.
+		for _, s := range []string{"a6", "b6", "c6", "d6", "e6", "f6", "g6", "h6"} {
+			if !c.IsAttacked(sq(t, s), gochess.Black) {
+				t.Errorf("expected %s attacked by black", s)
+			}
+		}
+		// e4 not attacked by anyone in start position.
+		if c.IsAttacked(sq(t, "e4"), gochess.White) {
+			t.Errorf("e4 should not be attacked by white in start position")
+		}
+		if c.IsAttacked(sq(t, "e4"), gochess.Black) {
+			t.Errorf("e4 should not be attacked by black in start position")
+		}
+	})
+
+	t.Run("knight attacks", func(t *testing.T) {
+		c := mustNew(t, "8/8/8/3N4/8/8/8/k6K w - - 0 1")
+		for _, s := range []string{"b6", "c7", "e7", "f6", "f4", "e3", "c3", "b4"} {
+			if !c.IsAttacked(sq(t, s), gochess.White) {
+				t.Errorf("expected %s attacked by white knight", s)
+			}
+		}
+		if c.IsAttacked(sq(t, "d6"), gochess.White) {
+			t.Errorf("d6 should not be attacked by knight on d5")
+		}
+	})
+
+	t.Run("rook attacks", func(t *testing.T) {
+		c := mustNew(t, "8/8/8/3R4/8/8/8/k6K w - - 0 1")
+		if !c.IsAttacked(sq(t, "d1"), gochess.White) {
+			t.Error("d1 should be attacked by rook on d5")
+		}
+		if !c.IsAttacked(sq(t, "a5"), gochess.White) {
+			t.Error("a5 should be attacked by rook on d5")
+		}
+		if c.IsAttacked(sq(t, "e6"), gochess.White) {
+			t.Error("e6 should not be attacked by rook on d5")
+		}
+	})
+
+	t.Run("bishop attacks", func(t *testing.T) {
+		c := mustNew(t, "8/8/8/3B4/8/8/8/k6K w - - 0 1")
+		if !c.IsAttacked(sq(t, "a8"), gochess.White) {
+			t.Error("a8 should be attacked by bishop on d5")
+		}
+		if !c.IsAttacked(sq(t, "h1"), gochess.White) {
+			t.Error("h1 should be attacked by bishop on d5")
+		}
+		if c.IsAttacked(sq(t, "d4"), gochess.White) {
+			t.Error("d4 should not be attacked by bishop on d5")
+		}
+	})
+
+	t.Run("queen attacks file and diagonal", func(t *testing.T) {
+		c := mustNew(t, "8/8/8/3Q4/8/8/8/k6K w - - 0 1")
+		if !c.IsAttacked(sq(t, "d1"), gochess.White) {
+			t.Error("d1 should be attacked by queen on d5 (file)")
+		}
+		if !c.IsAttacked(sq(t, "h1"), gochess.White) {
+			t.Error("h1 should be attacked by queen on d5 (diagonal)")
+		}
+	})
+
+	t.Run("blocked ray", func(t *testing.T) {
+		c := mustNew(t, "8/8/8/3R4/3P4/8/8/k6K w - - 0 1")
+		if c.IsAttacked(sq(t, "d1"), gochess.White) {
+			t.Error("d1 should not be attacked: pawn on d4 blocks rook")
+		}
+	})
+
+	t.Run("replaces check detection", func(t *testing.T) {
+		// Black king on e8, white rook on e1. King is in check.
+		c := mustNew(t, "4k3/8/8/8/8/8/8/4R1K1 b - - 0 1")
+		if !c.IsAttacked(sq(t, "e8"), gochess.White) {
+			t.Error("e8 should be attacked by white rook on e1")
+		}
+		if !c.IsCheck() {
+			t.Error("position should report check")
+		}
+	})
+}
+
+func TestAttackedBy(t *testing.T) {
+	t.Run("pawn and knight together", func(t *testing.T) {
+		// Square e4: attacked by white pawn d3 and white knight f2? Place pieces.
+		c := mustNew(t, "k6K/8/8/8/8/3P4/5N2/8 w - - 0 1")
+		ps := c.AttackedBy(sq(t, "e4"), gochess.White)
+		if !ps.Has(PawnSet) {
+			t.Errorf("expected PawnSet, got %s", ps)
+		}
+		if !ps.Has(KnightSet) {
+			t.Errorf("expected KnightSet, got %s", ps)
+		}
+		if ps.Has(BishopSet) || ps.Has(RookSet) || ps.Has(QueenSet) || ps.Has(KingSet) {
+			t.Errorf("unexpected extra bits: %s", ps)
+		}
+	})
+
+	t.Run("no attackers", func(t *testing.T) {
+		c := mustNew(t, "")
+		if got := c.AttackedBy(sq(t, "e4"), gochess.White); got != NoPieces {
+			t.Errorf("expected NoPieces, got %s", got)
+		}
+	})
+
+	t.Run("rook and queen on same file", func(t *testing.T) {
+		// White queen d8, white rook d4, target d1 — only rook reaches first.
+		// AttackedBy stops at first same-side piece on each ray.
+		c := mustNew(t, "3Q4/8/8/8/3R4/8/8/k2K4 w - - 0 1")
+		ps := c.AttackedBy(sq(t, "d1"), gochess.White)
+		if !ps.Has(RookSet) {
+			t.Errorf("expected RookSet, got %s", ps)
+		}
+		if ps.Has(QueenSet) {
+			t.Errorf("queen should be x-ray-blocked for AttackedBy: %s", ps)
+		}
+	})
+}
+
+func TestPawnAttackMap(t *testing.T) {
+	c := mustNew(t, "")
+	white := c.PawnAttackMap(gochess.White)
+	black := c.PawnAttackMap(gochess.Black)
+
+	// White pawns on rank 2 (y=6) attack rank 3 (y=5): all 8 files.
+	var expectedWhite uint64
+	for x := 0; x < 8; x++ {
+		expectedWhite |= uint64(1) << uint(5*8+x)
+	}
+	if white != expectedWhite {
+		t.Errorf("white pawn map mismatch: got %064b want %064b", white, expectedWhite)
+	}
+
+	var expectedBlack uint64
+	for x := 0; x < 8; x++ {
+		expectedBlack |= uint64(1) << uint(2*8+x)
+	}
+	if black != expectedBlack {
+		t.Errorf("black pawn map mismatch: got %064b want %064b", black, expectedBlack)
+	}
+}
+
+func TestAttackers(t *testing.T) {
+	t.Run("two rooks on same file (x-ray)", func(t *testing.T) {
+		// White rooks on d4 and d8 attacking d1.
+		c := mustNew(t, "3R4/8/8/8/3R4/8/8/k2K4 w - - 0 1")
+		got := c.Attackers(sq(t, "d1"), gochess.White, nil)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 attackers, got %d: %v", len(got), got)
+		}
+		// Both should be rooks (cheapest tier here).
+		want1, want2 := sq(t, "d4"), sq(t, "d8")
+		ok := (got[0] == want1 && got[1] == want2) || (got[0] == want2 && got[1] == want1)
+		if !ok {
+			t.Errorf("unexpected attackers: %v", got)
+		}
+	})
+
+	t.Run("queen behind rook on file (x-ray cross-type)", func(t *testing.T) {
+		// White rook d4, white queen d8. Both should be returned for d1.
+		c := mustNew(t, "3Q4/8/8/8/3R4/8/8/k2K4 w - - 0 1")
+		got := c.Attackers(sq(t, "d1"), gochess.White, nil)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 attackers, got %d: %v", len(got), got)
+		}
+		// Rook (cheaper) must come before queen.
+		if got[0] != sq(t, "d4") {
+			t.Errorf("rook should be first, got %v", got)
+		}
+		if got[1] != sq(t, "d8") {
+			t.Errorf("queen should be second, got %v", got)
+		}
+	})
+
+	t.Run("bishop behind queen on diagonal", func(t *testing.T) {
+		// White queen on b2, white bishop on a1. Target h8.
+		// Queen reaches h8 diagonally; bishop on a1 is x-ray behind queen.
+		c := mustNew(t, "8/8/8/8/8/8/1Q6/B3k2K w - - 0 1")
+		got := c.Attackers(sq(t, "h8"), gochess.White, nil)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 attackers, got %d: %v", len(got), got)
+		}
+		// Bishop is cheaper than queen, so it must come first.
+		if got[0] != sq(t, "a1") {
+			t.Errorf("bishop should be first (cheapest), got %v", got)
+		}
+		if got[1] != sq(t, "b2") {
+			t.Errorf("queen should be second, got %v", got)
+		}
+	})
+
+	t.Run("mixed cheapest-first ordering", func(t *testing.T) {
+		// White pawn c2 (no, c2 attacks b3/d3), let's place:
+		// Target e4: attacker pawn d3, knight f2, bishop b1, queen e1 (file).
+		c := mustNew(t, "7k/8/7K/8/8/3P4/5N2/4Q2B w - - 0 1")
+		got := c.Attackers(sq(t, "e4"), gochess.White, nil)
+		// Expect pawn first, then knight, then bishop, then queen.
+		if len(got) != 4 {
+			t.Fatalf("expected 4 attackers, got %d: %v", len(got), got)
+		}
+		if got[0] != sq(t, "d3") {
+			t.Errorf("pawn first, got %v", got)
+		}
+		if got[1] != sq(t, "f2") {
+			t.Errorf("knight second, got %v", got)
+		}
+		if got[2] != sq(t, "h1") {
+			t.Errorf("bishop third, got %v", got)
+		}
+		if got[3] != sq(t, "e1") {
+			t.Errorf("queen fourth, got %v", got)
+		}
+	})
+
+	t.Run("appends to dst", func(t *testing.T) {
+		c := mustNew(t, "")
+		dst := make([]gochess.Coordinate, 0, 8)
+		dst = append(dst, sq(t, "a1"))
+		got := c.Attackers(sq(t, "e3"), gochess.White, dst)
+		if len(got) < 1 || got[0] != sq(t, "a1") {
+			t.Errorf("dst prefix not preserved: %v", got)
+		}
+	})
+}
+
+func TestIsAttackedQueen(t *testing.T) {
+	t.Run("queen on file", func(t *testing.T) {
+		c := mustNew(t, "4k3/8/8/8/3q4/8/7K/8 b - - 0 1")
+		if !c.IsAttacked(sq(t, "d1"), gochess.Black) {
+			t.Error("d1 should be attacked by black queen on d4 (file)")
+		}
+	})
+	t.Run("queen on diagonal", func(t *testing.T) {
+		c := mustNew(t, "4k3/8/8/8/3q4/8/7K/8 b - - 0 1")
+		if !c.IsAttacked(sq(t, "g1"), gochess.Black) {
+			t.Error("g1 should be attacked by black queen on d4 (diagonal)")
+		}
+	})
+}

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -709,10 +709,7 @@ func (c Chess) isLegalMove(move string) bool {
 
 	c.makeMove(move)
 	kingPosition := c.kingsPosition(kingsColor)
-	opponent := gochess.Black
-	if kingsColor == gochess.Black {
-		opponent = gochess.White
-	}
+	opponent := opponentColor(kingsColor)
 	kingUnderAttack := c.IsAttacked(kingPosition, opponent)
 	c.unmakeMove()
 

--- a/chess/moves.go
+++ b/chess/moves.go
@@ -628,21 +628,6 @@ func expectedEPRank(capturingColor gochess.Piece) int {
 	return 5
 }
 
-// destinationMatch looks for a destination in a list of moves.
-// It returns true if any of the moves has the destination.
-// The function expects the moves in UCI format.
-func destinationMatch(moves []string, destination gochess.Coordinate) bool {
-	algCoor := CoordinateToAlgebraic(destination)
-	for _, move := range moves {
-		dest := move[2:4]
-		if dest == algCoor {
-			return true
-		}
-	}
-
-	return false
-}
-
 // legalMoves returns the legal moves for the current turn.
 func (c Chess) legalMoves() []string {
 	moves := c.availableMoves()
@@ -723,11 +708,12 @@ func (c Chess) isLegalMove(move string) bool {
 	kingsColor := c.turn
 
 	c.makeMove(move)
-
-	availableMoves := c.availableMoves()
 	kingPosition := c.kingsPosition(kingsColor)
-
-	kingUnderAttack := destinationMatch(availableMoves, kingPosition)
+	opponent := gochess.Black
+	if kingsColor == gochess.Black {
+		opponent = gochess.White
+	}
+	kingUnderAttack := c.IsAttacked(kingPosition, opponent)
 	c.unmakeMove()
 
 	// If the king is under attack, the move is not legal.
@@ -744,7 +730,7 @@ func (c Chess) isLegalMove(move string) bool {
 			return false
 		}
 		// (2) Cannot castle through check (king passage square under attack).
-		if destinationMatch(availableMoves, castleKingWay[move]) {
+		if c.IsAttacked(castleKingWay[move], opponent) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `IsAttacked`, `AttackedBy`, `PawnAttackMap` and `Attackers` (`chess/attacks.go`) plus `PieceSet` bitmask
- Replace the "toggle color, generate every opponent move, scan king destination" check detection in `isCheck` and `isLegalMove` with targeted `IsAttacked` lookups; castling king-passage check uses the same path
- `Attackers` walks each ray once and x-rays through any same-side slider matching the ray type (rook+queen on straight rays, bishop+queen on diagonals), and emits results cheapest-first for SEE

## Test plan
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] New `TestIsAttacked`, `TestAttackedBy`, `TestPawnAttackMap`, `TestAttackers`, `TestIsAttackedQueen` cover pawn/knight/rook/bishop/queen attacks, blocked rays, x-ray (two rooks, queen-behind-rook, bishop-behind-queen), cheapest-first ordering, dst append behaviour, and the start-position pawn attack bitmap.

Part 4 of 7.